### PR TITLE
Add Security Considerations section adapted from N-Quads.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -875,8 +875,8 @@
       per [[RFC3986]] <a data-cite="RFC3986#section-5.1.1">section 5.1.1, "Base URI Embedded in Content"</a>.
       <a data-cite="RFC3986#section-5.1.2">Section 5.1.2, "Base URI from the Encapsulating Entity"</a>
       defines how the In-Scope Base IRI may come from an encapsulating document,
-      such as a SOAP envelope with an xml:base directive or a mime multipart document with a
-      Content-Location header.
+      such as a SOAP envelope with an `xml:base` directive or a MIME multipart document with a
+      `Content-Location` header.
       The "Retrieval URI" identified in <a data-cite="RFC3986#section-5.1.3">5.1.3, Base "URI from the Retrieval URI"</a>,
       is the URL from which a particular <a>Turtle document</a> was retrieved.
       If none of the above specifies the Base URI, the default

--- a/spec/index.html
+++ b/spec/index.html
@@ -814,7 +814,9 @@
 
   <p>A conforming <dfn>Turtle document</dfn> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>, starting with the <a href="#grammar-production-turtleDoc"><code>turtleDoc</code> production</a>. A <a>Turtle document</a> serializes an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>.</p>
 
-  <p>A conforming <strong>Turtle parser</strong> is a system capable of reading Turtle documents on behalf of an application. It makes the serialized RDF dataset, as defined in <a href="#sec-parsing" class="sectionRef"></a>, available to the application, usually through some form of API.</p>
+  <p>A conforming <strong>Turtle parser</strong> is a system capable of reading Turtle documents on behalf of an application.
+    It makes the serialized RDF graph, as defined in <a href="#sec-parsing" class="sectionRef"></a>,
+    available to the application, usually through some form of API.</p>
 
   <p>The IRI that identifies the Turtle language is: <code>http://www.w3.org/ns/formats/Turtle</code></p>
 
@@ -869,11 +871,18 @@
     Characters additionally allowed in IRI references are treated in the same way that unreserved characters are treated in URI references, per section 6.5 of [[[RFC3987]]] [[RFC3987]].
     </p>
     <p>
-      The <code>@base</code> or <code>BASE</code> directive defines the Base IRI used to resolve relative IRIs per RFC3986 section 5.1.1, "Base URI Embedded in Content".
-      Section 5.1.2, "Base URI from the Encapsulating Entity" defines how the In-Scope Base IRI may come from an encapsulating document, such as a SOAP envelope with an xml:base directive or a mime multipart document with a Content-Location header.
-      The "Retrieval URI" identified in 5.1.3, Base "URI from the Retrieval URI", is the URL from which a particular <a>Turtle document</a> was retrieved.
-      If none of the above specifies the Base URI, the default Base URI (section 5.1.4, "Default Base URI") is used.
-      Each <code>@base</code> or <code>BASE</code> directive sets a new In-Scope Base URI, relative to the previous one.
+      The <code>@base</code> or <code>BASE</code> directive defines the Base IRI used to resolve relative IRIs
+      per [[RFC3986]] <a data-cite="RFC3986#section-5.1.1">section 5.1.1, "Base URI Embedded in Content"</a>.
+      <a data-cite="RFC3986#section-5.1.2">Section 5.1.2, "Base URI from the Encapsulating Entity"</a>
+      defines how the In-Scope Base IRI may come from an encapsulating document,
+      such as a SOAP envelope with an xml:base directive or a mime multipart document with a
+      Content-Location header.
+      The "Retrieval URI" identified in <a data-cite="RFC3986#section-5.1.3">5.1.3, Base "URI from the Retrieval URI"</a>,
+      is the URL from which a particular <a>Turtle document</a> was retrieved.
+      If none of the above specifies the Base URI, the default
+      Base URI (<a data-cite="RFC3986#section-5.1.4">section 5.1.4, "Default Base URI"</a>) is used.
+      Each <code>@base</code> or <code>BASE</code> directive sets a new In-Scope Base URI,
+      relative to the previous one.
     </p>
   </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -81,7 +81,7 @@
   general-purpose language for representing information in the Web.</p>
 
   <p>This document defines a textual syntax for RDF called Turtle
-  that allows an RDF graph to be completely written in a compact and
+  that allows an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> to be completely written in a compact and
   natural text form, with abbreviations for common usage patterns and
   datatypes.  Turtle provides levels of compatibility with the
   N-Triples [[RDF12-N-TRIPLES]]
@@ -107,7 +107,7 @@
   </p>
 
   <p>
-    A Turtle document is a textual representations of an RDF graph.
+    A <a>Turtle document</a> is a textual representations of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>.
     The following Turtle document describes the relationship between
     Green Goblin and Spiderman.
   </p>
@@ -151,7 +151,7 @@
   </p>
 
   <p>
-    The construction of an RDF graph from a Turtle document is defined in
+    The construction of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> from a <a>Turtle document</a> is defined in
     <a href="#sec-grammar" class="sectionRef">Turtle Grammar</a>
     and <a href="#sec-parsing" class="sectionRef">Parsing</a>.
   </p>
@@ -159,8 +159,8 @@
 
 <section id="language-features" class="informative">
   <h2>Turtle Language</h2>
-  <p>A Turtle document allows writing down an RDF graph in a compact textual form.
-    An RDF graph is made up of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triples</a>
+  <p>A <a>Turtle document</a> allows writing down an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> in a compact textual form.
+    An <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> is made up of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triples</a>
     consisting of a subject, predicate and object.</p>
   <p>Comments may be given after a '<code>#</code>' that is not part of
     another lexical token and continue to the end of the line.</p>
@@ -808,11 +808,11 @@
   <p>This specification defines conformance criteria for:</p>
 
   <ul>
-    <li>Turtle documents
-    <li>Turtle parsers
+    <li>Turtle documents</li>
+    <li>Turtle parsers</li>
   </ul>
 
-  <p>A conforming <strong>Turtle document</strong> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>, starting with the <a href="#grammar-production-turtleDoc"><code>turtleDoc</code> production</a>. A Turtle document serializes an RDF Graph.</p>
+  <p>A conforming <dfn>Turtle document</dfn> is a Unicode string that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>, starting with the <a href="#grammar-production-turtleDoc"><code>turtleDoc</code> production</a>. A <a>Turtle document</a> serializes an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>.</p>
 
   <p>A conforming <strong>Turtle parser</strong> is a system capable of reading Turtle documents on behalf of an application. It makes the serialized RDF dataset, as defined in <a href="#sec-parsing" class="sectionRef"></a>, available to the application, usually through some form of API.</p>
 
@@ -836,7 +836,7 @@
 <section id="sec-grammar">
   <h2>Turtle Grammar</h2>
 
-  <p>A Turtle document is a
+  <p>A <a>Turtle document</a> is a
   Unicode[[!UNICODE]]
   character string encoded in UTF-8.
   Unicode characters only in the range U+0000 to U+10FFFF inclusive are
@@ -871,7 +871,7 @@
     <p>
       The <code>@base</code> or <code>BASE</code> directive defines the Base IRI used to resolve relative IRIs per RFC3986 section 5.1.1, "Base URI Embedded in Content".
       Section 5.1.2, "Base URI from the Encapsulating Entity" defines how the In-Scope Base IRI may come from an encapsulating document, such as a SOAP envelope with an xml:base directive or a mime multipart document with a Content-Location header.
-      The "Retrieval URI" identified in 5.1.3, Base "URI from the Retrieval URI", is the URL from which a particular Turtle document was retrieved.
+      The "Retrieval URI" identified in 5.1.3, Base "URI from the Retrieval URI", is the URL from which a particular <a>Turtle document</a> was retrieved.
       If none of the above specifies the Base URI, the default Base URI (section 5.1.4, "Default Base URI") is used.
       Each <code>@base</code> or <code>BASE</code> directive sets a new In-Scope Base URI, relative to the previous one.
     </p>
@@ -1236,7 +1236,7 @@
     <h3>RDF Triples Constructors</h3>
 
     <p>
-      A Turtle document defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> composed of set of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>s.
+      A <a>Turtle document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> composed of set of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>s.
       The <code><a href="#grammar-production-subject">subject</a></code> production sets the <code class="curSubject">curSubject</code>.
       The <code><a href="#grammar-production-verb">verb</a></code> production sets the <code class="curPredicate">curPredicate</code>.
       Each <a tabindex="30" class="grammarRef" href="#grammar-production-object">object</a> <code>N</code>
@@ -1311,6 +1311,69 @@
   </section>
 </section>
 
+<section id="privacy-considerations">
+  <h2>Privacy Considerations</h2>
+  <p class="ednote">TODO</p>  
+</section>
+
+<section id="security">
+  <h2>Security Considerations</h2>
+
+  <p>The <a href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE">STRING_LITERAL_SINGLE_QUOTE</a>,
+    <a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a>,
+    <a href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a>, and
+    <a href="#grammar-production-STRING_LITERAL_LONG_QUOTE">STRING_LITERAL_LONG_QUOTE</a>,
+    productions allow the use of unescaped control characters.
+    Although this specification does not directly expose this content to an end user,
+    it might be presented through a user agent, which may cause the presented text to 
+    be obfuscated due to presentation of such characters.</p>
+
+  <p>Turtle is a general-purpose assertion language;
+    applications may evaluate given data to infer more assertions or to dereference <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>,
+    invoking the security considerations of the scheme for that IRI.
+    Note in particular, the privacy issues in [[RFC3023]] section 10 for HTTP IRIs.
+    Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions,
+    as well as the dereferencing of unintended IRIs.
+    Care must be taken to align the trust in consulted resources with the sensitivity of
+    the intended use of the data;
+    inferences of potential medical treatments would likely require different trust than inferences
+    for trip planning.</p>
+
+  <p>The Turtle language is used to express arbitrary application data;
+    security considerations will vary by domain of use.
+    Security tools and protocols applicable to text
+    (for example, PGP encryption, checksum validation, password-protected compression)
+    may also be used on <a>Turtle documents</a>.
+    Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</p>
+
+  <p>Turtle can express data which is presented to the user, such as RDF Schema labels.
+    Applications rendering strings retrieved from untrusted <a>Turtle documents</a>,
+    or using unescaped characters,
+    SHOULD use warnings and other appropriate means to limit the possibility
+    that malignant strings might be used to mislead the reader.
+    The security considerations in the media type registration for XML ([[!RFC3023]] section 10)
+    provide additional guidance around the expression of arbitrary data and markup.</p>
+
+  <p>Turtle uses <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> as term identifiers.
+    Applications interpreting data expressed in Turtle SHOULD address the security issues of
+    [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
+    [[[!RFC3986]]] [[!RFC3986]] Section 7.</p>
+
+  <p>Multiple <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> may have the same appearance.
+    Characters in different scripts may look similar (for instance,
+    a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;).
+    A character followed by combining characters may have the same visual representation
+    as another character (for example, LATIN SMALL LETTER "E" followed by COMBINING ACUTE
+    ACCENT has the same visual representation as LATIN SMALL LETTER "E" WITH ACUTE).
+    <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
+    Any person or application that is writing or interpreting data in Turtle
+    must take care to use the IRI that matches the intended semantics,
+    and avoid IRIs that may look similar.
+    Further information about matching visually similar characters can be found
+    in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
+    [[[RFC3987]]] [[RFC3987]] Section 8.</p>
+</section>
+
 <section id="in-html" class="appendix informative">
   <h2>Embedding Turtle in HTML documents</h2>
 
@@ -1375,7 +1438,7 @@
 
     <p>There are no syntactic or grammar differences between parsing Turtle
       that has been embedded and normal Turtle documents.
-      A Turtle document parsed from an HTML DOM will be a stream
+      A <a>Turtle document</a> parsed from an HTML DOM will be a stream
       of character data rather than a stream of UTF-8 encoded bytes.
       No decoding is necessary if the HTML document has already been parsed into DOM.
       Each <code>script</code> data block is considered to be it's own Turtle document.
@@ -1418,30 +1481,7 @@
     <dd>The syntax of Turtle is expressed over code points in Unicode [[!UNICODE]]. The encoding is always UTF-8 [[!UTF-8]].</dd>
     <dd>Unicode code points may also be expressed using an \uXXXX (U+0000 to U+FFFF) or \UXXXXXXXX syntax (for U+10000 onwards) where X is a hexadecimal digit [0-9A-Fa-f]</dd>
     <dt>Security considerations:</dt>
-    <dd>Turtle is a general-purpose assertion language; applications may evaluate given data to infer more assertions or to dereference IRIs, invoking the security considerations of the scheme for that IRI. Note in particular, the privacy issues in [[!RFC3023]] section 10 for HTTP IRIs. Data obtained from an inaccurate or malicious data source may lead to inaccurate or misleading conclusions, as well as the dereferencing of unintended IRIs. Care must be taken to align the trust in consulted resources with the sensitivity of the intended use of the data; inferences of potential medical treatments would likely require different trust than inferences for trip planning.</dd>
-
-    <dd>Turtle is used to express arbitrary application data; security considerations will vary by domain of use. Security tools and protocols applicable to text (e.g. PGP encryption, MD5 sum validation, password-protected compression) may also be used on Turtle documents. Security/privacy protocols must be imposed which reflect the sensitivity of the embedded information.</dd>
-    <dd>Turtle can express data which is presented to the user, for example, RDF Schema labels. Application rendering strings retrieved from untrusted Turtle documents must ensure that malignant strings MUST NOT be used to mislead the reader. The security considerations in the media type registration for XML ([[!RFC3023]] section 10) provide additional guidance around the expression of arbitrary data and markup.</dd>
-    <dd>Turtle uses IRIs as term identifiers. Applications interpreting data expressed in Turtle should address the security issues of
-      [[[!RFC3987]]] [[!RFC3987]] Section 8, as well as
-      [[![RFC3986]]] [[!RFC3986]] Section 7.</dd>
-
-    <dd>Multiple IRIs may have the same appearance. Characters in different scripts may
-      look similar (a Cyrillic &quot;&#1086;&quot; may appear similar to a Latin &quot;o&quot;). A character followed
-      by combining characters may have the same visual representation as another character
-      (LATIN SMALL LETTER E followed by COMBINING ACUTE ACCENT has the same visual representation
-      as LATIN SMALL LETTER E WITH ACUTE).
-      <!-- (<code>foo:resum&#40751;code> and <code>f&#1086;&#1086;:resume&#769;</code>)-->
-      Any person or application that is writing or interpreting data in Turtle must take care to use the IRI that matches the intended semantics, and avoid IRIs that make look similar.
-      Further information about matching of similar characters can be found
-      in [[[UNICODE-SECURITY]]] [[UNICODE-SECURITY]] and
-      [[[RFC3987]]] [[RFC3987]] Section 8.
-
-      <!--@@ no security considerations section at this time. @@
-      See Turtle - Terse RDF Triple Language appendix X, <a href="#security">Security Considerations</a>
-          as well as <a class="norm" href="http://www.ietf.org/rfc/rfc3629.txt">RFC 3629</a>
-          [<a href="#rfc3629">RFC3629</a>] section 7, Security Considerations. -->
-    </dd>
+    <dd>See <a href="#security" class="sectionRef"></a>.</dd>
     <dt>Interoperability considerations:</dt>
     <dd>There are no known interoperability issues.</dd>
     <dt>Published specification:</dt>
@@ -1571,6 +1611,8 @@
   <ul>
     <li>Update informative restrictions on included characters for `STRING_LITERAL_QUOTE`
       and `STRING_LITERAL_SINGLE_QUOTE`.</li>
+    <li>Separated <a href="#security"></a> from <a href="#sec-mediaReg"></a>
+      and updated language.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Also adds sub Privacy Considerations section and minor cleanup of conformance.

Defines Turtle document and Turtle parser terms.

Fixes #9.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/14.html" title="Last updated on Apr 6, 2023, 8:42 PM UTC (8505ca9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/14/47c761d...8505ca9.html" title="Last updated on Apr 6, 2023, 8:42 PM UTC (8505ca9)">Diff</a>