### PR TITLE
Update Turtle grammar for quoted triples and annotations

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -124,7 +124,10 @@
     Green Goblin and Spiderman.
   </p>
 
-  <pre class="example turtle" data-transform="updateExample">
+  <pre id="ex-intro"
+       class="example turtle"
+       data-transform="updateExample"
+       title="Example Turtle">
     <!--
     @base <http://example.org/> .
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -181,7 +184,9 @@
     <h3>Simple Triples</h3>
     <p>The simplest triple statement is a sequence of (subject, predicate, object) terms,
       separated by whitespace and terminated by '<code>.</code>' after each triple.</p>
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-simple-triple"
+         class="example turtle" data-transform="updateExample"
+         title="Simple Triple">
       <!--
       <http://example.org/#spiderman>
         <http://www.perceive.net/schemas/relationship/enemyOf>
@@ -202,14 +207,18 @@
       that vary only in predicate and object RDF terms.</p>
       <p>These two examples are equivalent ways of writing the triples about Spiderman.</p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-predicateObjectList"
+         class="example turtle" data-transform="updateExample"
+         title="Predicate List">
       <!--
       <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> ;
         <http://xmlns.com/foaf/0.1/name> "Spiderman" .
       -->
     </pre>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-predicateObjectList-expanded"
+         class="example turtle" data-transform="updateExample"
+         title="Predicate List expanded to Simiple Triples">
       <!--
       <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman" .
@@ -230,13 +239,17 @@
 
     <p>These two examples  are equivalent ways of writing Spiderman's name in two languages.<p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-object-list"
+         class="example turtle" data-transform="updateExample"
+         title="Object List">
       <!--
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman", "Человек-паук"@ru .
       -->
     </pre>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-object-list-expanded"
+         class="example turtle" data-transform="updateExample"
+         title="Object List expanded to Simple Triples">
       <!--
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman" .
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Человек-паук"@ru .
@@ -305,7 +318,9 @@
 
     <p>This can be written using either the original Turtle syntax for prefix declarations:</p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-prefix-decl"
+         class="example turtle" data-transform="updateExample"
+         title="Original syntax for prefix declarations">
       <!--
       @prefix somePrefix: <http://www.perceive.net/schemas/relationship/> .
 
@@ -315,7 +330,9 @@
 
     <p>or SPARQL's syntax for prefix declarations:</p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-sparql-prefix-decl"
+         class="example turtle" data-transform="updateExample"
+         title="SPARQL syntax for prefix declarations">
       <!--
       PREFIX somePrefix: <http://www.perceive.net/schemas/relationship/>
 
@@ -337,7 +354,9 @@
 
     <p>The following Turtle document contains examples of all the different ways of writing IRIs in Turtle.</p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-turtle-abbreviations"
+         class="example turtle" data-transform="updateExample"
+         title="Different ways of writing IRIs">
       <!--
       # A triple with all absolute IRIs
       <http://one.example/subject1> <http://one.example/predicate1> <http://one.example/object1> .
@@ -379,7 +398,9 @@
 
     <p><a data-cite="RDF12-CONCEPTS#dfn-literal">Literals</a> are used to identify values such as strings, numbers, dates.</p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-rdf-literal"
+         class="example turtle" data-transform="updateExample"
+         title="Literals in Turtle">
       <!--
       @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
@@ -437,7 +458,9 @@
           <code>"""</code>.</li>
       </ul>
 
-      <pre class="example turtle" data-transform="updateExample">
+      <pre id="ex-quoted-literals"
+           class="example turtle" data-transform="updateExample"
+           title="Quoted Literals">
         <!--
         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
         @prefix show: <http://example.org/vocab/show/> .
@@ -517,7 +540,9 @@
         </tbody>
       </table>
  -->
-      <pre class="example turtle" data-transform="updateExample">
+      <pre id="ex-numbers"
+           class="example turtle" data-transform="updateExample"
+           title="Number Literalss">
         <!--
         @prefix : <http://example.org/elements> .
         <http://en.wikipedia.org/wiki/Helium>
@@ -533,7 +558,9 @@
       <p>Boolean values may be written as either '<code>true</code>'
         or '<code>false</code>' (case-sensitive)
         and represent RDF literals with the datatype <a data-cite="xmlschema11-2#boolean">xsd:boolean</a>.</p>
-      <pre class="example turtle" data-transform="updateExample">
+      <pre it="ex-boolean"
+           class="example turtle" data-transform="updateExample"
+           title="Boolean Literals">
         <!--
         @prefix : <http://example.org/stats> .
         <http://somecountry.example/census2007>
@@ -567,7 +594,9 @@
       A fresh RDF <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> is allocated for each unique <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> in a document.
       Repeated use of the same <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifier</a> identifies the same blank node.
     </p>
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-blank-node"
+         class="example turtle" data-transform="updateExample"
+         title="Blank Node in Turtle">
       <!--
       @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
@@ -595,7 +624,9 @@
       Blank nodes are also allocated for <a href="#collections">collections</a>
       described below.
     </p>
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-blankNodePropertyList"
+         class="example turtle" data-transform="updateExample"
+         title="Blank Node Property List">
       <!--
       @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 
@@ -674,7 +705,9 @@
       The <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> at the head of the list is the subject or object of the containing triple.
     </p>
 
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-collection"
+         class="example turtle" data-transform="updateExample"
+         title="Collections in Turtle">
       <!--
       @prefix : <http://example.org/foo> .
       # the object of this triple is the RDF collection blank node
@@ -700,7 +733,9 @@
   <div data-include="examples/example1.ttl" data-oninclude="updateExample"></div>
 
   <p>An example of an RDF collection of two literals.</p>
-  <pre class="example turtle" data-transform="updateExample">
+  <pre id="ex-collection-two-literals"
+       class="example turtle" data-transform="updateExample"
+       title="RDF collection of two literals">
     <!--
     PREFIX : <http://example.org/stuff/1.0/>
     :a :b ( "apple" "banana" ) .
@@ -728,7 +763,9 @@
 
   <p>For example,</p>
 
-  <pre  class="example turtle untested" data-transform="updateExample">
+  <pre id="ex-collection-as-subject"
+       class="example turtle untested" data-transform="updateExample"
+       title="Collection used as Subject">
     <!--
     @prefix : <http://example.org/stuff/1.0/> .
     (1 2.0 3E1) :p "w" .
@@ -738,7 +775,9 @@
   <p>is syntactic sugar for (noting that the <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a> <code>b0</code>, <code>b1</code> and <code>b2</code>
     do not occur anywhere else in the RDF graph):</p>
 
-  <pre  class="example turtle untested" data-transform="updateExample">
+  <pre id="ex-collection-as-subject-expanded"
+       class="example turtle untested" data-transform="updateExample"
+       title="Collection represented with Blank Nodes">
     <!--
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix : <http://example.org/stuff/1.0/>
@@ -754,7 +793,9 @@
 
   <p>RDF collections can be nested and can involve other syntactic forms:</p>
 
-  <pre  class="example turtle untested" data-transform="updateExample">
+  <pre id="ex-nested-collection"
+       class="example turtle untested" data-transform="updateExample"
+       title="Nested Collections">
     <!--
     PREFIX : <http://example.org/stuff/1.0/>
     (1 [:p :q] ( 2 ) ) :p2 :q2 .
@@ -762,7 +803,9 @@
   </pre>
 
   <p>is syntactic sugar for:</p>
-  <pre class="example turtle untested" data-transform="updateExample">
+  <pre id="ex-nested-collection-expanded"
+       class="example turtle untested" data-transform="updateExample"
+       title="Nested Collections represented with Blank Nodes">
     <!--
     @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
     @prefix : <http://example.org/stuff/1.0/>
@@ -1296,7 +1339,9 @@
     <h3>Parsing Example</h3>
 
     <p>The following informative example shows the semantic actions performed when  parsing this Turtle document with an LALR(1) parser:</p>
-    <pre class="example turtle" data-transform="updateExample">
+    <pre id="ex-parsing"
+         class="example turtle" data-transform="updateExample"
+         title="Example of parsing Turtle">
       <!--
         @prefix ericFoaf: <http://www.w3.org/People/Eric/ericP-foaf.rdf#> .
         @prefix : <http://xmlns.com/foaf/0.1/> .
@@ -1341,7 +1386,9 @@
     -->
     can be used to embed data blocks in documents. Turtle can be easily embedded in HTML this way.</p>
 
-  <pre class="example html" data-transform="updateExample">
+  <pre id="ex-html-embedding"
+       class="example html" data-transform="updateExample"
+       title="Embedding Turtle in HTML">
     <!--
     <script type="text/turtle">
       @prefix dc: <http://purl.org/dc/terms/> .
@@ -1375,7 +1422,9 @@
     (<code>application/xhtml+xml</code>). The solution is the same one used for JavaScript.
     </p>
 
-    <pre class="example html" data-transform="updateExample">
+    <pre id="ex-xhtml-embedding"
+         class="example html" data-transform="updateExample"
+         title="Embedding Turtle in XHTML">
       <!--
       <script type="text/turtle">
         ****# <![CDATA[****

--- a/spec/index.html
+++ b/spec/index.html
@@ -61,8 +61,8 @@
     .separated tbody tr td { border:1px solid black; text-align: center; min-width: 10vw }
     .separated tbody tr td.r { text-align: right; padding: .5em; }
     .grammar td { font-family: monospace; vertical-align: top; }
-    .grammar-literal { color: gray;}
-    .grammar_comment { color: #A52A2A; font-style: italic; }
+    .grammar-paren { color: gray;}
+    .grammar-brac { color: gray;}
     .hl-bold { font-weight: bold; color: #0a3; }
     code { color: #ff4500; }  /* Old W3C Style */
     var { color: #ff4500; }
@@ -1250,12 +1250,12 @@
             <span>[162s]</span>
             <span><code>ANON</code></span>
             <span>::=</span>
-            <span>'<code class="grammar-literal">[</code>'
+            <span>'<code class="grammar-brac">[</code>'
               <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code>
-              '<code class="grammar-literal">]</code>'</span>
+              '<code class="grammar-brac">]</code>'</span>
           </span>
           token allows any amount of white space and comments between
-          <code class="grammar-literal">[]</code>s.
+          <code class="grammar-brac">[]</code>s.
           The single space version is used in the grammar for clarity.
         </li>
         <li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -568,7 +568,7 @@
       <p>Boolean values may be written as either '<code>true</code>'
         or '<code>false</code>' (case-sensitive)
         and represent RDF literals with the datatype <a data-cite="xmlschema11-2#boolean">xsd:boolean</a>.</p>
-      <pre it="ex-boolean"
+      <pre id="ex-boolean"
            class="example turtle" data-transform="updateExample"
            title="Boolean Literals">
         <!--
@@ -797,7 +797,7 @@
       </pre>
       <p>is the same set of triples as:</p>
       <pre id="ex-annotated-triple-expanded"
-           class="nohighlight example"data-transform="updateExample"
+           class="nohighlight example" data-transform="updateExample"
            title="Annotated Triple expanded to Quoted Triples">
         <!--
         PREFIX : <http://example.com/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -746,7 +746,7 @@
       <code><a href="#grammar-production-object">object</a></code>
       preceded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
       Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
-      may be recursive.
+      may be nested.
      </p>
 
     <pre id="ex-quoted-triple"

--- a/spec/index.html
+++ b/spec/index.html
@@ -63,12 +63,14 @@
     .grammar td { font-family: monospace; vertical-align: top; }
     .grammar-paren { color: gray;}
     .grammar-brac { color: gray;}
+    .grammar_comment { color: #A52A2A; font-style: italic; }
     #grammar-declaration-terminals h3 {
       margin-top: 1em;
     }
     .hl-bold { font-weight: bold; color: #0a3; }
     code { color: #ff4500; }  /* Old W3C Style */
     var { color: #ff4500; }
+    abbr[title] {text-decoration: none;}
     @media (max-width: 850px) {
         table th, table td { font-size: 12px; padding: 3px 4px;}
         table.ex th, table.ex td {overflow-x: scroll; max-width: 42vw !important;}

--- a/spec/index.html
+++ b/spec/index.html
@@ -1245,20 +1245,6 @@
           In signed numbers, no white space is allowed between the sign and the number.
         </li>
         <li>
-          The
-          <span style="font-size: smaller;">
-            <span>[162s]</span>
-            <span><code>ANON</code></span>
-            <span>::=</span>
-            <span>'<code class="grammar-brac">[</code>'
-              <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code>
-              '<code class="grammar-brac">]</code>'</span>
-          </span>
-          token allows any amount of white space and comments between
-          <code class="grammar-brac">[]</code>s.
-          The single space version is used in the grammar for clarity.
-        </li>
-        <li>
           The strings '<a href="#grammar-production-prefixID"><code class="grammar-literal">@prefix</code></a>'
           and '<a href="#grammar-production-base"><code class="grammar-literal">@base</code></a>'
           match the pattern for <a href="#grammar-production-LANGTAG">LANGTAG</a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -563,7 +563,7 @@
  -->
       <pre id="ex-numbers"
            class="example turtle" data-transform="updateExample"
-           title="Number Literalss">
+           title="Number Literals">
         <!--
         @prefix : <http://example.org/elements> .
         <http://en.wikipedia.org/wiki/Helium>

--- a/spec/index.html
+++ b/spec/index.html
@@ -89,17 +89,27 @@
 <body>
 <section id='abstract'>
   <p>The Resource Description Framework
-  (<abbr title="Resource Description Framework">RDF</abbr>) is a
-  general-purpose language for representing information in the Web.</p>
+    (<abbr title="Resource Description Framework">RDF</abbr>) is a
+    general-purpose language for representing information in the Web.</p>
 
   <p>This document defines a textual syntax for RDF called Turtle
-  that allows an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> to be completely written in a compact and
-  natural text form, with abbreviations for common usage patterns and
-  datatypes.  Turtle provides levels of compatibility with the
-  N-Triples [[RDF12-N-TRIPLES]]
-  format as well as the triple pattern syntax of
-  [[[SPARQL12-QUERY]]] W3C Recommendation.
-  </p>
+    that allows an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> to be completely written in a compact and
+    natural text form, with abbreviations for common usage patterns and
+    datatypes.  Turtle provides levels of compatibility with the
+    N-Triples [[RDF12-N-TRIPLES]]
+    format as well as the triple pattern syntax of
+    [[[SPARQL12-QUERY]]] W3C Recommendation.</p>
+
+  <p>RDF 1.2 Turtle introduces <a>quoted triples</a>
+    as a fourth kind of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF term</a>
+    which can be used as the
+    <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+    <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of another
+    <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
+    making it possible to make statements about other statements.</p>
+
+  <p>RDF 1.2 Turtle also introduces an <a>annotation syntax</a> which allows
+    <a>quoted triples</a> to also be <a data-lt="asserted triple">asserted</a>.</p>
 </section>
 
 <section id='sotd'>
@@ -255,15 +265,15 @@
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Человек-паук"@ru .
       -->
     </pre>
-
   </section>
 
   <p>
     There are three types of <em>RDF Term</em> defined in RDF Concepts:
     <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a> (Internationalized Resource Identifiers),
-    <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a> and
-    <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>. Turtle provides a number
-    of ways of writing each.
+    <a data-cite="RDF12-CONCEPTS#dfn-literal">literals</a>,
+    <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>, and.
+    <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>,
+    Turtle provides a number of ways of writing each.
   </p>
 
   <section id="sec-iri">
@@ -717,6 +727,87 @@
       :subject :predicate2 () .
       -->
     </pre>
+
+  </section>
+
+  <section id="quoted-triples">
+    <h3>Quoted Triples</h3>
+
+    <p>A <dfn data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</dfn>
+      may be the <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
+      <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of an
+      <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>.</p>
+
+    <p>A <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+      is represented using the <code><a href="#grammar-production-quotedTriple">quotedTriple</a></code> production
+      with <code><a href="#grammar-production-subject">subject</a></code>,
+      <code><a href="#grammar-production-predicate">predicate</a></code>, and
+      <code><a href="#grammar-production-object">object</a></code>
+      preceded by <code>&lt;&lt;</code> and followed by <code>&gt;&gt;</code>.
+      Note that <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triples</a>
+      may be recursive.
+     </p>
+
+    <pre id="ex-quoted-triple"
+         class="example turtle" data-transform="updateExample"
+         title="Quoted Triple">
+      <!--
+      PREFIX :    <http://www.example.org/>
+
+      :employee38 :familyName "Smith" .
+      << :employee38 :jobTitle "Assistant Designer" >> :accordingTo :employee22 .
+      -->
+    </pre>
+
+    <p>After declaring a prefix so that IRIs can be abbreviated,
+      the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
+      Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";
+      it says that `employee22` has made that claim.
+      In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
+      is not what we call an <dfn data-cite="RDF12-CONCEPTS#dfn-asserted-triple">asserted triple</dfn>,
+      like "employee38 has a `familyName` of 'Smith'" above;
+      rather, it is known as a <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>.</p>
+
+    <section id="annotation-syntax">
+      <h2>Annotation Syntax</h2>
+      <p>Turtle also defines an <dfn data-lt="annotation-syntax">annotation syntax</dfn>
+        to both quote and assert a <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triple</a>,
+        which provides a convenient shortcut.
+        An annotation can be used to both assert a triple and have that triple be the
+        <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> of further triples.
+        The delimiters `{|` and `|}` follow an
+        <a>asserted triple</a> to make that triple,
+        as a <a>quoted triple</a>,
+        the <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a>
+        of the <a href="#grammar-production-predicateObjectList">predicateObjectList</a>
+        contained within the annotation delimeters.
+      </p>
+
+      <p class="note">The annotation syntax is a syntactic short cut in Turtle,
+        and the RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
+        distinguished how the triples were written.</p>
+
+      <pre id="ex-annotated-triple"
+           class="example turtle" data-transform="updateExample" 
+           title="Annotated Triple">
+        <!--
+        PREFIX : <http://example.com/>
+        :a :name "Alice" {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .
+          -->
+      </pre>
+      <p>is the same set of triples as:</p>
+      <pre id="ex-annotated-triple-expanded"
+           class="nohighlight example"data-transform="updateExample"
+           title="Annotated Triple expanded to Quoted Triples">
+        <!--
+        PREFIX : <http://example.com/>
+        << :a :name "Alice" >> :statedBy :bob .
+        << :a :name "Alice" >> :recorded "2021-07-07"^^xsd:date .
+        :a :name "Alice"
+         -->
+      </pre>
+      <p>and the graph contains three <a>asserted triples</a>.</p>
+    </section>
 
   </section>
 </section>
@@ -1629,6 +1720,9 @@
       and `STRING_LITERAL_SINGLE_QUOTE`.</li>
     <li>Separated <a href="#security"></a> from <a href="#sec-mediaReg"></a>
       and updated language.</li>
+    <li>Added <a href="#quoted-triples" class="sectionRef"></a>
+      and <a href="#annotation-syntax" class="sectionRef"></a>
+      for representing <a>quoted triples</a> in Turtle.</li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -61,7 +61,12 @@
     .separated tbody tr td { border:1px solid black; text-align: center; min-width: 10vw }
     .separated tbody tr td.r { text-align: right; padding: .5em; }
     .grammar td { font-family: monospace; vertical-align: top; }
-    .grammar-paren { color: gray;}
+    .grammar-opt,
+    .grammar-alt,
+    .grammar-paren,
+    .grammar-diff,
+    .grammar-plus,
+    .grammar-star,
     .grammar-brac { color: gray;}
     .grammar_comment { color: #A52A2A; font-style: italic; }
     #grammar-declaration-terminals h3 {

--- a/spec/index.html
+++ b/spec/index.html
@@ -65,6 +65,7 @@
     .grammar_comment { color: #A52A2A; font-style: italic; }
     .hl-bold { font-weight: bold; color: #0a3; }
     code { color: #ff4500; }  /* Old W3C Style */
+    var { color: #ff4500; }
     @media (max-width: 850px) {
         table th, table td { font-size: 12px; padding: 3px 4px;}
         table.ex th, table.ex td {overflow-x: scroll; max-width: 42vw !important;}
@@ -1295,10 +1296,10 @@
   <section id="sec-parsing-state">
     <h3>Parser State</h3>
 
-    <p>Parsing Turtle requires a state of five items:</p>
+    <p>Parsing Turtle requires a state of six items:</p>
 
     <ul>
-      <li id="baseURI">IRI <code class="dfn">baseURI</code>
+      <li id="baseURI">IRI |baseURI|
         — When the <a href="#grammar-production-base">base
         production</a> is reached, the second rule argument,
         <code>IRIREF</code>, is the base URI used for relative
@@ -1312,8 +1313,7 @@
 
       <li id="namespaces">Map[<a class="type prefix" href="#prefix">prefix</a>
         -&gt; IRI]
-        <code class="dfn">namespaces</code>
-        — The second and third rule arguments
+        |namespaces| — The second and third rule arguments
         (<code>PNAME_NS</code> and <code>IRIREF</code>)
         in the <a href="#grammar-production-prefixID">prefixID production</a>
         assign a namespace name (<code>IRIREF</code>) for the prefix
@@ -1332,56 +1332,75 @@
       </li>
 
       <li id="bnodeLabels">Map[<a class="type string" href="#string">string</a>
-        -&gt; <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>] <code class="dfn">bnodeLabels</code>
+        -&gt; <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>] |bnodeLabels|
         — A mapping from string to blank node.</li>
 
-      <li id="curSubject">RDF_Term <code class="dfn">curSubject</code>
-        — The <code class="curSubject">curSubject</code> is bound to the
-        <code><a href="#grammar-production-subject">subject</a></code> production.</li>
+      <li id="curSubject">RDF_Term |curSubject|
+        — The |curSubject| is bound to the
+        <code><a href="#grammar-production-subject">subject</a></code>
+        and <code><a href="#grammar-production-qtSubject">qtSubject</a></code> productions.</li>
 
-      <li id="curPredicate">RDF_Term <code class="dfn">curPredicate</code>
-        — The <code class="curPredicate">curPredicate</code> is bound to
+      <li id="curPredicate">RDF_Term |curPredicate|
+        — The |curPredicate| is bound to
         the <code><a href="#grammar-production-verb">verb</a></code> production.
         If token matched was "<code>a</code>",
-        <code class="curPredicate">curPredicate</code> is bound to the IRI
+        |curPredicate| is bound to the IRI
         <code>http://www.w3.org/1999/02/22-rdf-syntax-ns#type</code>.
         <!--
           <span class="testrefs">(test: <a href="tests/#type">type</a>)</span>
         -->
       </li>
+      <li id="curObject">RDF_Term |curObject| —
+        The |curObject| is bound to the
+        <a href="#grammar-production-object">`object`</a>
+        <a href="#grammar-production-qtObject">`qtObject`</a> productions.</li>
     </ul>
+    <p>Additionally, |curSubject|
+      can be bound to any RDF_Term
+      (including a <a>quoted triple</a>).</p>
   </section>
 
   <section  id="sec-parsing-terms">
     <h3>RDF Term Constructors</h3>
 
-    <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
+    <p>This table maps productions and lexical tokens to <code>RDF terms</code>
+      or components of <code>RDF terms</code>
+      listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
 
     <table id="tab-term-constructors" class="separated">
       <thead>
         <tr><th>                                                                       production               </th><th>                                                                                       type            </th><th>procedure</th></tr>
       </thead>
       <tbody>
-      <tr id="handle-IRIREF"                          ><td style="text-align:left;"            ><a class="type IRI"         href="#grammar-production-IRIREF"                          >IRIREF                          </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>The characters between "&lt;" and "&gt;" are taken, with the <a href="#numeric">numeric escape sequences</a> unescaped, to form the unicode string of the IRI. <a data-cite="RDF12-CONCEPTS#dfn-relative-iri">Relative IRI reference</a> resolution is performed per <a href="#sec-iri-references" class="sectionRef">Section 6.3</a>.</td></tr>
-      <tr id="handle-PNAME_NS"                        ><td style="text-align:left;" rowspan="2"><a class="type string"      href="#grammar-production-PNAME_NS"                        >PNAME_NS                        </a></td><td><a href="#prefix">                         prefix      </a></td><td>When used in a <a href="#grammar-production-prefixID">prefixID</a> or <a href="#grammar-production-sparqlPrefix">sparqlPrefix</a> production, the <code>prefix</code> is the potentially empty unicode string matching the first argument of the rule is a key into the <a href="#namespaces">namespaces map</a>.</td></tr>
-      <tr id="handle-PNAME_NS2"                       >                                                                                                                                                                          <td><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>When used in a <a href="#grammar-production-PrefixedName">PrefixedName</a> production, the <code>iri</code> is the value in the <a href="#namespaces">namespaces map</a> corresponding to the first argument of the rule.</td></tr>
-      <tr id="handle-PNAME_LN"                        ><td style="text-align:left;"            ><a class="type IRI"         href="#grammar-production-PNAME_LN"                        >PNAME_LN                        </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>A potentially empty <a href="#prefix">prefix</a> is identified by the first sequence, <code>PNAME_NS</code>. The <a href="#namespaces">namespaces map</a> <em class="rfc2119">MUST</em> have a corresponding <code>namespace</code>. The unicode string of the IRI is formed by unescaping the <a href="#reserved">reserved characters</a> in the second argument, <code>PN_LOCAL</code>, and concatenating this onto the <code>namespace</code>.</td></tr>
-      <!-- tr id="handle-PrefixedName"                ><td style="text-align:left;"            ><a class="type IRI"         href="#grammar-production-PrefixedName"                    >PrefixedName                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>.</td></tr -->
-      <tr id="handle-STRING_LITERAL_SINGLE_QUOTE"     ><td style="text-align:left;"            ><a class="type lexicalForm" href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE"     >STRING_LITERAL_SINGLE_QUOTE     </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a></td><td>The characters between the outermost "'"s   are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
-      <tr id="handle-STRING_LITERAL_QUOTE"            ><td style="text-align:left;"            ><a class="type lexicalForm" href="#grammar-production-STRING_LITERAL_QUOTE"            >STRING_LITERAL_QUOTE            </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a></td><td>The characters between the outermost '"'s   are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
-      <tr id="handle-STRING_LITERAL_LONG_SINGLE_QUOTE"><td style="text-align:left;"            ><a class="type lexicalForm" href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a></td><td>The characters between the outermost "'''"s are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
-      <tr id="handle-STRING_LITERAL_LONG_QUOTE"       ><td style="text-align:left;"            ><a class="type lexicalForm" href="#grammar-production-STRING_LITERAL_LONG_QUOTE"       >STRING_LITERAL_LONG_QUOTE       </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a></td><td>The characters between the outermost '"""'s are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
-      <tr id="handle-LANGTAG"                         ><td style="text-align:left;"            ><a class="type langTag"     href="#grammar-production-LANGTAG"                         >LANGTAG                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-language-tag">language tag</a></td><td>The characters following the <code>@</code> form the unicode string of the language tag.</td></tr>
-      <tr id="handle-RDFLiteral"                      ><td style="text-align:left;"            ><a class="type literal"     href="#grammar-production-RDFLiteral"                      >RDFLiteral                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">     literal     </a></td><td>The literal has a lexical form of the first rule argument, <code>String</code>. If the <code>'^^' iri</code> rule matched, the datatype is <code>iri</code> and the literal has no language tag. If the <code>LANGTAG</code> rule matched, the datatype is <code>rdf:langString</code> and the language tag is <code>LANGTAG</code>. If neither matched, the datatype is <code>xsd:string</code> and the literal has no language tag.</td></tr>
-      <tr id="handle-INTEGER"                         ><td style="text-align:left;"            ><a class="type integer"     href="#grammar-production-INTEGER"                         >INTEGER                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">     literal     </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:integer</code>.</td></tr>
-      <tr id="handle-DECIMAL"                         ><td style="text-align:left;"            ><a class="type decimal"     href="#grammar-production-DECIMAL"                         >DECIMAL                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">     literal     </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:decimal</code>.</td></tr>
-      <tr id="handle-DOUBLE"                          ><td style="text-align:left;"            ><a class="type double"      href="#grammar-production-DOUBLE"                          >DOUBLE                          </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">     literal     </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:double</code>.</td></tr>
-      <tr id="handle-BooleanLiteral"                  ><td style="text-align:left;"            ><a class="type boolean"     href="#grammar-production-BooleanLiteral"                  >BooleanLiteral                  </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">     literal     </a></td><td>The literal has a lexical form of the <code>true</code> or <code>false</code>, depending on which matched the input, and a datatype of <code>xsd:boolean</code>.</td></tr>
-      <tr id="handle-BLANK_NODE_LABEL"                ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-BLANK_NODE_LABEL"                >BLANK_NODE_LABEL                </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>The string matching the second argument, <code>PN_LOCAL</code>, is a key in <a href="#bnodeLabels">bnodeLabels</a>. If there is no corresponding <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> in the map, one is allocated.</td></tr>
-      <tr id="handle-ANON"                            ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-ANON"                            >ANON                            </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>A blank node is generated.</td></tr>
-      <tr id="handle-blankNodePropertyList"           ><td style="text-align:left;"            ><a class="type bNode"       href="#grammar-production-blankNodePropertyList"           >blankNodePropertyList           </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>A blank node is generated. Note the rules for <code>blankNodePropertyList</code> in the next section.</td></tr>
-      <tr id="handle-collection"                      ><td style="text-align:left;" rowspan="2"><a class="type bNode"       href="#grammar-production-collection"                      >collection                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">  blank node  </a></td><td>For non-empty lists, a blank node is generated. Note the rules for <code>collection</code> in the next section.</td></tr>
-      <tr id="handle-collection2"                     >                                                                                                                                                                          <td><a data-cite="RDF12-CONCEPTS#dfn-iri">         IRI         </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
+      <tr id="handle-IRIREF"                          ><td style="text-align:left;"            ><a class="type IRI"          href="#grammar-production-IRIREF"                          >IRIREF                          </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a></td><td>The characters between "&lt;" and "&gt;" are taken, with the <a href="#numeric">numeric escape sequences</a> unescaped, to form the unicode string of the IRI. <a data-cite="RDF12-CONCEPTS#dfn-relative-iri">Relative IRI reference</a> resolution is performed per <a href="#sec-iri-references" class="sectionRef">Section 6.3</a>.</td></tr>
+      <tr id="handle-PNAME_NS"                        ><td style="text-align:left;" rowspan="2"><a class="type string"       href="#grammar-production-PNAME_NS"                        >PNAME_NS                        </a></td><td><a href="#prefix">                              prefix       </a></td><td>When used in a <a href="#grammar-production-prefixID">prefixID</a> or <a href="#grammar-production-sparqlPrefix">sparqlPrefix</a> production, the <code>prefix</code> is the potentially empty unicode string matching the first argument of the rule is a key into the <a href="#namespaces">namespaces map</a>.</td></tr>
+      <tr id="handle-PNAME_NS2"                       >                                                                                                                                                                           <td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a></td><td>When used in a <a href="#grammar-production-PrefixedName">PrefixedName</a> production, the <code>iri</code> is the value in the <a href="#namespaces">namespaces map</a> corresponding to the first argument of the rule.</td></tr>
+      <tr id="handle-PNAME_LN"                        ><td style="text-align:left;"            ><a class="type IRI"          href="#grammar-production-PNAME_LN"                        >PNAME_LN                        </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a></td><td>A potentially empty <a href="#prefix">prefix</a> is identified by the first sequence, <code>PNAME_NS</code>. The <a href="#namespaces">namespaces map</a> <em class="rfc2119">MUST</em> have a corresponding <code>namespace</code>. The unicode string of the IRI is formed by unescaping the <a href="#reserved">reserved characters</a> in the second argument, <code>PN_LOCAL</code>, and concatenating this onto the <code>namespace</code>.</td></tr>
+      <!-- tr id="handle-PrefixedName"                ><td style="text-align:left;"            ><a class="type IRI"          href="#grammar-production-PrefixedName"                    >PrefixedName                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a></td><td>.</td></tr -->
+      <tr id="handle-STRING_LITERAL_SINGLE_QUOTE"     ><td style="text-align:left;"            ><a class="type lexicalForm"  href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE"     >STRING_LITERAL_SINGLE_QUOTE     </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form"> lexical form </a></td><td>The characters between the outermost "'"s   are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
+      <tr id="handle-STRING_LITERAL_QUOTE"            ><td style="text-align:left;"            ><a class="type lexicalForm"  href="#grammar-production-STRING_LITERAL_QUOTE"            >STRING_LITERAL_QUOTE            </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form"> lexical form </a></td><td>The characters between the outermost '"'s   are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
+      <tr id="handle-STRING_LITERAL_LONG_SINGLE_QUOTE"><td style="text-align:left;"            ><a class="type lexicalForm"  href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form"> lexical form </a></td><td>The characters between the outermost "'''"s are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
+      <tr id="handle-STRING_LITERAL_LONG_QUOTE"       ><td style="text-align:left;"            ><a class="type lexicalForm"  href="#grammar-production-STRING_LITERAL_LONG_QUOTE"       >STRING_LITERAL_LONG_QUOTE       </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-lexical-form"> lexical form </a></td><td>The characters between the outermost '"""'s are taken, with <a href="#numeric">numeric</a> and <a href="#string">string</a> escape sequences unescaped, to form the unicode string of a lexical form.</td></tr>
+      <tr id="handle-LANGTAG"                         ><td style="text-align:left;"            ><a class="type langTag"      href="#grammar-production-LANGTAG"                         >LANGTAG                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-language-tag"> language tag </a></td><td>The characters following the <code>@</code> form the unicode string of the language tag.</td></tr>
+      <tr id="handle-RDFLiteral"                      ><td style="text-align:left;"            ><a class="type literal"      href="#grammar-production-RDFLiteral"                      >RDFLiteral                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">      literal      </a></td><td>The literal has a lexical form of the first rule argument, <code>String</code>. If the <code>'^^' iri</code> rule matched, the datatype is <code>iri</code> and the literal has no language tag. If the <code>LANGTAG</code> rule matched, the datatype is <code>rdf:langString</code> and the language tag is <code>LANGTAG</code>. If neither matched, the datatype is <code>xsd:string</code> and the literal has no language tag.</td></tr>
+      <tr id="handle-INTEGER"                         ><td style="text-align:left;"            ><a class="type integer"      href="#grammar-production-INTEGER"                         >INTEGER                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">      literal      </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:integer</code>.</td></tr>
+      <tr id="handle-DECIMAL"                         ><td style="text-align:left;"            ><a class="type decimal"      href="#grammar-production-DECIMAL"                         >DECIMAL                         </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">      literal      </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:decimal</code>.</td></tr>
+      <tr id="handle-DOUBLE"                          ><td style="text-align:left;"            ><a class="type double"       href="#grammar-production-DOUBLE"                          >DOUBLE                          </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">      literal      </a></td><td>The literal has a lexical form of the input string, and a datatype of <code>xsd:double</code>.</td></tr>
+      <tr id="handle-BooleanLiteral"                  ><td style="text-align:left;"            ><a class="type boolean"      href="#grammar-production-BooleanLiteral"                  >BooleanLiteral                  </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-literal">      literal      </a></td><td>The literal has a lexical form of the <code>true</code> or <code>false</code>, depending on which matched the input, and a datatype of <code>xsd:boolean</code>.</td></tr>
+      <tr id="handle-BLANK_NODE_LABEL"                ><td style="text-align:left;"            ><a class="type bNode"        href="#grammar-production-BLANK_NODE_LABEL"                >BLANK_NODE_LABEL                </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">   blank node   </a></td><td>The string matching the second argument, <code>PN_LOCAL</code>, is a key in <a href="#bnodeLabels">bnodeLabels</a>. If there is no corresponding <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a> in the map, one is allocated.</td></tr>
+      <tr id="handle-ANON"                            ><td style="text-align:left;"            ><a class="type bNode"        href="#grammar-production-ANON"                            >ANON                            </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">   blank node   </a></td><td>A blank node is generated.</td></tr>
+      <tr id="handle-blankNodePropertyList"           ><td style="text-align:left;"            ><a class="type bNode"        href="#grammar-production-blankNodePropertyList"           >blankNodePropertyList           </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">   blank node   </a></td><td>A blank node is generated. Note the rules for <code>blankNodePropertyList</code> in the next section.</td></tr>
+      <tr id="handle-collection"                      ><td style="text-align:left;" rowspan="2"><a class="type bNode"        href="#grammar-production-collection"                      >collection                      </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-blank-node">   blank node   </a></td><td>For non-empty lists, a blank node is generated. Note the rules for <code>collection</code> in the next section.</td></tr>
+      <tr id="handle-collection2"                     >                                                                                                                                                                           <td><a data-cite="RDF12-CONCEPTS#dfn-iri">          IRI          </a></td><td>For empty lists, the resulting IRI is <code>rdf:nil</code>. Note the rules for <code>collection</code> in the next section.</td></tr>
+      <tr id="handle-quotedTriple"                    ><td style="text-align:left;"            ><a class="type quotedTriple" href="#grammar-production-quotedTriple"                    >quotedTriple                    </a></td><td><a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a></td>
+        <td>
+          The <a data-cite="RDF12-CONCEPTS#dfn-quoted-triple">quoted triple</a>
+          is composed of the terms constructed from
+          the <code><a href="#grammar-production-subject">subject</a></code>,
+          <code><a href="#grammar-production-predicate">predicate</a></code>, and
+          <code><a href="#grammar-production-object">object</a></code> productions.
+        </td>
+      </tr>
       </tbody>
     </table>
 
@@ -1392,25 +1411,38 @@
 
     <p>
       A <a>Turtle document</a> defines an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> composed of set of <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">RDF triple</a>s.
-      The <code><a href="#grammar-production-subject">subject</a></code> production sets the <code class="curSubject">curSubject</code>.
-      The <code><a href="#grammar-production-verb">verb</a></code> production sets the <code class="curPredicate">curPredicate</code>.
+      The <code><a href="#grammar-production-subject">subject</a></code> and <code><a href="#grammar-production-qtSubject">qtSubject</a></code> productions set the |curSubject|.
+      The <code><a href="#grammar-production-verb">verb</a></code> production sets the |curPredicate|.
+      The <code><a href="#grammar-production-object">object</a></code> and <code><a href="#grammar-production-qtObject">qtObject</a></code> productions set the }curObject|.
       Each <a tabindex="30" class="grammarRef" href="#grammar-production-object">object</a> <code>N</code>
       in the document produces an RDF triple:
-      <span class="ntriple"><code class="curSubject">curSubject</code>
-        <code class="curPredicate">curPredicate</code> <code>N</code> .</span>
+      <span class="ntriple">|curSubject|
+        |curPredicate| <code>N</code> .</span>
     </p>
+
+    <p>Beginning the <a href="#grammar-production-quotedTriple">`quotedTriple`</a> production
+      records the |curSubject| and |curPredicate|.
+      Finishing the <a href="#grammar-production-quotedTriple">`quotedTriple`</a> production
+      yields the RDF triple |curSubject| |curPredicate| |curObject|
+      and restores the recorded values of |curSubject| and |curPredicate|.</p>
+
+    <p>Beginning the <a href="#grammar-production-annotation">`annotation`</a> production
+      records the |curSubject| and |curPredicate|,
+      and sets the |curSubject| to the RDF triple |curSubject| |curPredicate| |curObject|.
+      Finishing the <a href="#grammar-production-annotation">`annotation`</a> production
+      restores the recorded values of |curSubject| and |curPredicate|.</p>
 
     <h4 id="propertyList" style="padding-bottom:0; margin-bottom:0;"><span>Property Lists:</span></h4>
 
     <p style="padding-top:0; margin-top:0;">
       Beginning the <code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a></code>
-      production records the <code class="curSubject">curSubject</code>
-      and <code class="curPredicate">curPredicate</code>,
-      and sets <code class="curSubject">curSubject</code>
+      production records the |curSubject|
+      and |curPredicate|,
+      and sets |curSubject|
       to a novel <code>blank node</code> <code>B</code>.
       Finishing the <code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a></code>
-      production restores <code class="curSubject">curSubject</code>
-      and <code class="curPredicate">curPredicate</code>.
+      production restores |curSubject|
+      and |curPredicate|.
       The node produced by matching <code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a></code>
       is the blank node <code>B</code>.
     </p>
@@ -1418,10 +1450,10 @@
     <h4 id="collection" style="padding-bottom:0; margin-bottom:0;"><span>Collections:</span></h4>
 
     <p style="padding-top:0; margin-top:0;">
-      Beginning the <code><a href="#grammar-production-collection">collection</a></code> production records the <code class="curSubject">curSubject</code> and <code class="curPredicate">curPredicate</code>.
-      Each <code>object</code> in the <code><a href="#grammar-production-collection">collection</a></code> production has a <code class="curSubject">curSubject</code> set to a novel <code>blank node</code> <code>B</code> and a <code class="curPredicate">curPredicate</code> set to <code>rdf:first</code>.
+      Beginning the <code><a href="#grammar-production-collection">collection</a></code> production records the |curSubject| and |curPredicate|.
+      Each <code>object</code> in the <code><a href="#grammar-production-collection">collection</a></code> production has a |curSubject| set to a novel <code>blank node</code> <code>B</code> and a |curPredicate| set to <code>rdf:first</code>.
       For each object <code>object<sub>n</sub></code> after the first produces a triple:<span class="ntriple"><code>object<sub>n-1</sub></code> <code>rdf:rest</code> <code>object<sub>n</sub></code> .</span>
-      Finishing the <code><a href="#grammar-production-collection">collection</a></code> production creates an additional triple <span class="ntriple"><code>curSubject rdf:rest rdf:nil</code> .</span> and restores <code class="curSubject">curSubject</code> and <code class="curPredicate">curPredicate</code>
+      Finishing the <code><a href="#grammar-production-collection">collection</a></code> production creates an additional triple <span class="ntriple"><code>curSubject rdf:rest rdf:nil</code> .</span> and restores |curSubject| and |curPredicate|
       The node produced by matching <code><a href="#grammar-production-collection">collection</a></code> is the first blank node <code>B</code> for non-empty lists and <code>rdf:nil</code> for empty lists.
     </p>
   </section>
@@ -1446,22 +1478,22 @@
     <ul>
       <li>Map the prefix <code>ericFoaf</code> to the IRI <code>http://www.w3.org/People/Eric/ericP-foaf.rdf#</code>.</li>
       <li>Map the empty prefix to the IRI <code>http://xmlns.com/foaf/0.1/</code>.</li>
-      <li>Assign <code class="curSubject">curSubject</code> the IRI <code>http://www.w3.org/People/Eric/ericP-foaf.rdf#ericP</code>.</li>
+      <li>Assign |curSubject| the IRI <code>http://www.w3.org/People/Eric/ericP-foaf.rdf#ericP</code>.</li>
 
-      <li>Assign <code class="curPredicate">curPredicate</code> the IRI <code>http://xmlns.com/foaf/0.1/givenName</code>.</li>
+      <li>Assign |curPredicate| the IRI <code>http://xmlns.com/foaf/0.1/givenName</code>.</li>
       <li>Emit an RDF triple: <span class="ntriple"><code>&lt;...rdf#ericP&gt;</code> <code>&lt;.../givenName&gt;</code> <code>"Eric"</code> .</span></li>
 
-      <li>Assign <code class="curPredicate">curPredicate</code> the IRI <code>http://xmlns.com/foaf/0.1/knows</code>.</li>
+      <li>Assign |curPredicate| the IRI <code>http://xmlns.com/foaf/0.1/knows</code>.</li>
       <li>Emit an RDF triple: <span class="ntriple"><code>&lt;...rdf#ericP&gt;</code> <code>&lt;.../knows&gt;</code> <code>&lt;...who/dan-brickley&gt;</code> .</span></li>
 
       <li>Emit an RDF triple: <span class="ntriple"><code>&lt;...rdf#ericP&gt;</code> <code>&lt;.../knows&gt;</code> <code>_:1</code> .</span></li>
-      <li>Save <code class="curSubject">curSubject</code> and reassign to the blank node <code>_:1</code>.</li>
+      <li>Save |curSubject| and reassign to the blank node <code>_:1</code>.</li>
 
-      <li>Save <code class="curPredicate">curPredicate</code>.</li>
-      <li>Assign <code class="curPredicate">curPredicate</code> the IRI <code>http://xmlns.com/foaf/0.1/mbox</code>.</li>
+      <li>Save |curPredicate|.</li>
+      <li>Assign |curPredicate| the IRI <code>http://xmlns.com/foaf/0.1/mbox</code>.</li>
       <li>Emit an RDF triple: <span class="ntriple"><code>_:1</code> <code>&lt;.../mbox&gt;</code> <code>&lt;mailto:timbl@w3.org&gt;</code> .</span></li>
 
-      <li>Restore <code class="curSubject">curSubject</code> and <code class="curPredicate">curPredicate</code> to their saved values (<code>&lt;...rdf#ericP&gt;</code>, <code>&lt;.../knows&gt;</code>).</li>
+      <li>Restore |curSubject| and |curPredicate| to their saved values (<code>&lt;...rdf#ericP&gt;</code>, <code>&lt;.../knows&gt;</code>).</li>
       <li>Emit an RDF triple: <span class="ntriple"><code>&lt;...rdf#ericP&gt;</code> <code>&lt;.../knows&gt;</code> <code>&lt;http://getopenid.com/amyvdh&gt;</code> .</span></li>
 
     </ul>

--- a/spec/index.html
+++ b/spec/index.html
@@ -63,6 +63,9 @@
     .grammar td { font-family: monospace; vertical-align: top; }
     .grammar-paren { color: gray;}
     .grammar-brac { color: gray;}
+    #grammar-declaration-terminals h3 {
+      margin-top: 1em;
+    }
     .hl-bold { font-weight: bold; color: #0a3; }
     code { color: #ff4500; }  /* Old W3C Style */
     var { color: #ff4500; }

--- a/spec/index.html
+++ b/spec/index.html
@@ -463,7 +463,7 @@
         Turtle has a shorthand syntax for writing integer values,
         arbitrary precision decimal values, and double precision floating point values.</p>
 
-      <table class="separated">
+      <table id="tab-numbers" class="separated">
         <thead>
           <tr>
             <th>Data Type</th>
@@ -619,7 +619,7 @@
     is a common idiom for representing a series of properties of a node.
   </p>
 
-  <table class="ex">
+  <table id="tab-bnproplist" class="ex">
     <tr>
       <th class="idlAttrName" style="padding-left:2em;">Abbreviated:</th>
       <th class="idlAttrName" style="padding-left:2em;">Corresponding simple triples:</th>
@@ -907,7 +907,7 @@
       <li>
         <p><em id="numeric">numeric escape sequences</em> represent Unicode code points:</p>
 
-        <table>
+        <table id="tab-uchar">
           <thead>
             <tr>
               <th>Escape sequence</th>
@@ -954,7 +954,7 @@
           <em id="string">string escape sequences</em> represent the characters traditionally escaped in string literals:
         </p>
 
-        <table>
+        <table id="tab-echar">
           <thead>
             <tr>
               <th>Escape sequence</th>
@@ -1223,7 +1223,7 @@
 
     <p>This table maps productions and lexical tokens to <code>RDF terms</code> or components of <code>RDF terms</code> listed in <a href="#sec-parsing" class="sectionRef"></a>:</p>
 
-    <table class="separated">
+    <table id="tab-term-constructors" class="separated">
       <thead>
         <tr><th>                                                                       production               </th><th>                                                                                       type            </th><th>procedure</th></tr>
       </thead>

--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -1,23 +1,24 @@
 
+<!-- Generated with ebnf version #{EBNF::VERSION}. See https://github.com/dryruby/ebnf. -->
 <table class="grammar">
   <tbody id="grammar-productions" class="ebnf">
     <tr id="grammar-production-turtleDoc">
       <td>[1]</td>
       <td><code>turtleDoc</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-statement">statement</a><code>*</code> </td>
+      <td><a href="#grammar-production-statement">statement</a><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-statement">
       <td>[2]</td>
       <td><code>statement</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-directive">directive</a> <code>|</code> <code>(</code> <a href="#grammar-production-triples">triples</a> "<code class="grammar-literal">.</code>"<code>)</code> </td>
+      <td><a href="#grammar-production-directive">directive</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-triples">triples</a> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-directive">
       <td>[3]</td>
       <td><code>directive</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-prefixID">prefixID</a> <code>|</code> <a href="#grammar-production-base">base</a> <code>|</code> <a href="#grammar-production-sparqlPrefix">sparqlPrefix</a> <code>|</code> <a href="#grammar-production-sparqlBase">sparqlBase</a></td>
+      <td><a href="#grammar-production-prefixID">prefixID</a> <code class="grammar-alt">|</code> <a href="#grammar-production-base">base</a> <code class="grammar-alt">|</code> <a href="#grammar-production-sparqlPrefix">sparqlPrefix</a> <code class="grammar-alt">|</code> <a href="#grammar-production-sparqlBase">sparqlBase</a></td>
     </tr>
     <tr id="grammar-production-prefixID">
       <td>[4]</td>
@@ -47,31 +48,31 @@
       <td>[8]</td>
       <td><code>triples</code></td>
       <td>::=</td>
-      <td><code>(</code> <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code>)</code>  <code>|</code> <code>(</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code>?</code> <code>)</code> </td>
+      <td><code class="grammar-paren">(</code><a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-predicateObjectList">
       <td>[9]</td>
       <td><code>predicateObjectList</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a> <code>(</code> "<code class="grammar-literal">;</code>" <code>(</code> <a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a><code>)</code> <code>?</code> <code>)</code> <code>*</code> </td>
+      <td><a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a> <code class="grammar-paren">(</code>"<code class="grammar-literal">;</code>" <code class="grammar-paren">(</code><a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-objectList">
       <td>[10]</td>
       <td><code>objectList</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code>?</code>  <code>(</code> "<code class="grammar-literal">,</code>" <a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code>?</code> <code>)</code> <code>*</code> </td>
+      <td><a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code class="grammar-opt">?</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">,</code>" <a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code class="grammar-opt">?</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-verb">
       <td>[11]</td>
       <td><code>verb</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-predicate">predicate</a> <code>|</code> "<code class="grammar-literal">a</code>"</td>
+      <td><a href="#grammar-production-predicate">predicate</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">a</code>"</td>
     </tr>
     <tr id="grammar-production-subject">
       <td>[12]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-collection">collection</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
     <tr id="grammar-production-predicate">
       <td>[13]</td>
@@ -83,13 +84,13 @@
       <td>[14]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-collection">collection</a> <code>|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code>|</code> <a href="#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
     <tr id="grammar-production-literal">
       <td>[15]</td>
       <td><code>literal</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-RDFLiteral">RDFLiteral</a> <code>|</code> <a href="#grammar-production-NumericLiteral">NumericLiteral</a> <code>|</code> <a href="#grammar-production-BooleanLiteral">BooleanLiteral</a></td>
+      <td><a href="#grammar-production-RDFLiteral">RDFLiteral</a> <code class="grammar-alt">|</code> <a href="#grammar-production-NumericLiteral">NumericLiteral</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BooleanLiteral">BooleanLiteral</a></td>
     </tr>
     <tr id="grammar-production-blankNodePropertyList">
       <td>[16]</td>
@@ -101,49 +102,49 @@
       <td>[17]</td>
       <td><code>collection</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-object">object</a><code>*</code>  "<code class="grammar-literal">)</code>"</td>
+      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-object">object</a><code class="grammar-star">*</code> "<code class="grammar-literal">)</code>"</td>
     </tr>
     <tr id="grammar-production-NumericLiteral">
       <td>[18]</td>
       <td><code>NumericLiteral</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-INTEGER">INTEGER</a> <code>|</code> <a href="#grammar-production-DECIMAL">DECIMAL</a> <code>|</code> <a href="#grammar-production-DOUBLE">DOUBLE</a></td>
+      <td><a href="#grammar-production-INTEGER">INTEGER</a> <code class="grammar-alt">|</code> <a href="#grammar-production-DECIMAL">DECIMAL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-DOUBLE">DOUBLE</a></td>
     </tr>
     <tr id="grammar-production-RDFLiteral">
       <td>[19]</td>
       <td><code>RDFLiteral</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-String">String</a> <code>(</code> <a href="#grammar-production-LANGTAG">LANGTAG</a> <code>|</code> <code>(</code> &quot;^^&quot; <a href="#grammar-production-iri">iri</a><code>)</code> <code>)</code> <code>?</code> </td>
+      <td><a href="#grammar-production-String">String</a> <code class="grammar-paren">(</code><a href="#grammar-production-LANGTAG">LANGTAG</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>&quot;^^&quot; <a href="#grammar-production-iri">iri</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-BooleanLiteral">
       <td>[20]</td>
       <td><code>BooleanLiteral</code></td>
       <td>::=</td>
-      <td>&quot;true&quot; <code>|</code> &quot;false&quot;</td>
+      <td>&quot;true&quot; <code class="grammar-alt">|</code> &quot;false&quot;</td>
     </tr>
     <tr id="grammar-production-String">
       <td>[21]</td>
       <td><code>String</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE">STRING_LITERAL_SINGLE_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_LONG_QUOTE">STRING_LITERAL_LONG_QUOTE</a></td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code class="grammar-alt">|</code> <a href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE">STRING_LITERAL_SINGLE_QUOTE</a> <code class="grammar-alt">|</code> <a href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a> <code class="grammar-alt">|</code> <a href="#grammar-production-STRING_LITERAL_LONG_QUOTE">STRING_LITERAL_LONG_QUOTE</a></td>
     </tr>
     <tr id="grammar-production-iri">
       <td>[22]</td>
       <td><code>iri</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a href="#grammar-production-PrefixedName">PrefixedName</a></td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PrefixedName">PrefixedName</a></td>
     </tr>
     <tr id="grammar-production-PrefixedName">
       <td>[23]</td>
       <td><code>PrefixedName</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PNAME_LN">PNAME_LN</a> <code>|</code> <a href="#grammar-production-PNAME_NS">PNAME_NS</a></td>
+      <td><a href="#grammar-production-PNAME_LN">PNAME_LN</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PNAME_NS">PNAME_NS</a></td>
     </tr>
     <tr id="grammar-production-BlankNode">
       <td>[24]</td>
       <td><code>BlankNode</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-ANON">ANON</a></td>
+      <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-ANON">ANON</a></td>
     </tr>
     <tr id="grammar-production-quotedTriple">
       <td>[25]</td>
@@ -155,13 +156,13 @@
       <td>[26]</td>
       <td><code>qtSubject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
     <tr id="grammar-production-qtObject">
       <td>[27]</td>
       <td><code>qtObject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
     </tr>
     <tr id="grammar-production-annotation">
       <td>[28]</td>
@@ -178,13 +179,13 @@
       <td>[30]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;</code>" <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&apos;&gt;&apos;</code><code>]</code> </td>
+      <td>"<code class="grammar-literal">&lt;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&gt;</code>"</td>
     </tr>
     <tr id="grammar-production-PNAME_NS">
       <td>[31]</td>
       <td><code>PNAME_NS</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_PREFIX">PN_PREFIX</a><code>?</code>  "<code class="grammar-literal">:</code>"</td>
+      <td><a href="#grammar-production-PN_PREFIX">PN_PREFIX</a><code class="grammar-opt">?</code> "<code class="grammar-literal">:</code>"</td>
     </tr>
     <tr id="grammar-production-PNAME_LN">
       <td>[32]</td>
@@ -196,192 +197,192 @@
       <td>[33]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
-      <td>&quot;_:&quot; <code>(</code> <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>)</code>  <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>"<code>)</code> <code>*</code>  <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code>)</code> <code>?</code> </td>
+      <td>&quot;_:&quot; <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANGTAG">
       <td>[34]</td>
       <td><code>LANGTAG</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">@</code>" <code>[</code> <code class="grammar-literal">a-zA-Z</code><code>]</code> <code>+</code>  <code>(</code> "<code class="grammar-literal">-</code>" <code>[</code> <code class="grammar-literal">a-zA-Z0-9</code><code>]</code> <code>+</code> <code>)</code> <code>*</code> </td>
+      <td>"<code class="grammar-literal">@</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">-</code>" <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code></td>
     </tr>
     <tr id="grammar-production-INTEGER">
       <td>[35]</td>
       <td><code>INTEGER</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> </td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-DECIMAL">
       <td>[36]</td>
       <td><code>DECIMAL</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>*</code>  "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> <code>)</code> </td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> "<code class="grammar-literal">.</code>" <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-DOUBLE">
       <td>[37]</td>
       <td><code>DOUBLE</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>(</code> <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>*</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code>  <code>|</code> <code>(</code> "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code>  <code>|</code> <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code> <code>)</code> </td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> "<code class="grammar-literal">.</code>" <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">.</code>" <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-EXPONENT">
       <td>[38]</td>
       <td><code>EXPONENT</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">eE</code><code>]</code>  <code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> </td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">eE</code><code class="grammar-brac">]</code> <code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
       <td>[39]</td>
       <td><code>STRING_LITERAL_QUOTE</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&quot;</code>' <code>(</code> <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code>]</code>  <code>|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  '<code class="grammar-literal">&quot;</code>'</td>
+      <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE">
       <td>[40]</td>
       <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&apos;</code>" <code>(</code> <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="ascii '&apos;'">#x27</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code>]</code>  <code>|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  "<code class="grammar-literal">&apos;</code>"</td>
+      <td>"<code class="grammar-literal">&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="ascii '&apos;'">#x27</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;</code>"</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">
       <td>[41]</td>
       <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
       <td>::=</td>
-      <td>&quot;&apos;&apos;&apos;&quot; <code>(</code> <code>(</code> "<code class="grammar-literal">&apos;</code>" <code>|</code> &quot;&apos;&apos;&quot;<code>)</code> <code>?</code>  <code>[</code> <code class="grammar-literal">^&apos;]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">ECHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&quot;&apos;&apos;&apos;&quot;</code><code>]</code> <code>)</code> </td>
+      <td>&quot;&apos;&apos;&apos;&quot; <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> &quot;&apos;&apos;&quot;<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&apos;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> &quot;&apos;&apos;&apos;&quot;</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE">
       <td>[42]</td>
       <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
       <td>::=</td>
-      <td>&apos;&quot;&quot;&quot;&apos; <code>(</code> <code>(</code> '<code class="grammar-literal">&quot;</code>' <code>|</code> &apos;&quot;&quot;&apos;<code>)</code> <code>?</code>  <code>[</code> <code class="grammar-literal">^&quot;]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">ECHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&apos;&quot;&quot;&quot;&apos;</code><code>]</code> <code>)</code> </td>
+      <td>&apos;&quot;&quot;&quot;&apos; <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">&quot;</code>' <code class="grammar-alt">|</code> &apos;&quot;&quot;&apos;<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&quot;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> &apos;&quot;&quot;&quot;&apos;</td>
     </tr>
     <tr id="grammar-production-UCHAR">
       <td>[43]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
-      <td><code>(</code> "<code class="grammar-literal">u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code>  <code>|</code> <code>(</code> "<code class="grammar-literal">U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code> </td>
+      <td><code class="grammar-paren">(</code>&quot;\u&quot; <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>&quot;\U&quot; <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
       <td>[44]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">\</code>" <code>[</code> <code class="grammar-literal">tbnrf&quot;&apos;</code><code>]</code> </td>
+      <td>"<code class="grammar-literal">\</code>" <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-NIL">
       <td>[45]</td>
       <td><code>NIL</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-WS">WS</a><code>*</code>  "<code class="grammar-literal">)</code>"</td>
+      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> "<code class="grammar-literal">)</code>"</td>
     </tr>
     <tr id="grammar-production-WS">
       <td>[46]</td>
       <td><code>WS</code></td>
       <td>::=</td>
-      <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
+      <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
     </tr>
     <tr id="grammar-production-ANON">
       <td>[47]</td>
       <td><code>ANON</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">[</code>" <a href="#grammar-production-WS">WS</a><code>*</code>  "<code class="grammar-literal">]</code>"</td>
+      <td>"<code class="grammar-literal">[</code>" <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> "<code class="grammar-literal">]</code>"</td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
       <td>[48]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">A-Z</code><code>]</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">A-Z</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-literal">a-z</code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-z</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code>]</code></td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
       <td>|</td>
-      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code>]</code> </td>
+      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
       <td>[49]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code>|</code> "<code class="grammar-literal">_</code>"</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">_</code>"</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
       <td>[50]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> "<code class="grammar-literal">-</code>" <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xB7'">#xB7</abbr></code> <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x036F</abbr></code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2040</abbr></code><code>]</code> </td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">-</code>" <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xB7'">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_PREFIX">
       <td>[51]</td>
       <td><code>PN_PREFIX</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>"<code>)</code> <code>*</code>  <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code>)</code> <code>?</code> </td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL">
       <td>[52]</td>
       <td><code>PN_LOCAL</code></td>
       <td>::=</td>
-      <td><code>(</code> <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code>  <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>" <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code> <code>*</code>  <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code> <code>)</code> <code>?</code> </td>
+      <td><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">:</code>" <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">:</code>" <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">:</code>" <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PLX">
       <td>[53]</td>
       <td><code>PLX</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-PERCENT">PERCENT</a> <code>|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
+      <td><a href="#grammar-production-PERCENT">PERCENT</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
     </tr>
     <tr id="grammar-production-PERCENT">
       <td>[54]</td>
@@ -393,13 +394,13 @@
       <td>[55]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
-      <td><code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">A-F</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">a-f</code><code>]</code> </td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">A-F</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-f</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL_ESC">
       <td>[56]</td>
       <td><code>PN_LOCAL_ESC</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">\</code>" <code>(</code> "<code class="grammar-literal">_</code>" <code>|</code> "<code class="grammar-literal">~</code>" <code>|</code> "<code class="grammar-literal">.</code>" <code>|</code> "<code class="grammar-literal">-</code>" <code>|</code> "<code class="grammar-literal">!</code>" <code>|</code> "<code class="grammar-literal">$</code>" <code>|</code> "<code class="grammar-literal">&amp;</code>" <code>|</code> "<code class="grammar-literal">&apos;</code>" <code>|</code> "<code class="grammar-literal">(</code>" <code>|</code> "<code class="grammar-literal">)</code>" <code>|</code> "<code class="grammar-literal">*</code>" <code>|</code> "<code class="grammar-literal">+</code>" <code>|</code> "<code class="grammar-literal">,</code>" <code>|</code> "<code class="grammar-literal">;</code>" <code>|</code> "<code class="grammar-literal">=</code>" <code>|</code> "<code class="grammar-literal">/</code>" <code>|</code> "<code class="grammar-literal">?</code>" <code>|</code> "<code class="grammar-literal">#</code>" <code>|</code> "<code class="grammar-literal">@</code>" <code>|</code> "<code class="grammar-literal">%</code>"<code>)</code> </td>
+      <td>"<code class="grammar-literal">\</code>" <code class="grammar-paren">(</code>"<code class="grammar-literal">_</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">~</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">-</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">!</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">$</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">&amp;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">(</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">)</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">*</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">+</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">,</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">=</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">/</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">?</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">#</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">@</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">%</code>"<code class="grammar-paren">)</code></td>
     </tr>
   </tbody>
 </table>

--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -24,25 +24,25 @@
       <td>[4]</td>
       <td><code>prefixID</code></td>
       <td>::=</td>
-      <td>&quot;@prefix&quot; <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
+      <td>"<code class="grammar-literal">@prefix</code>" <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
     </tr>
     <tr id="grammar-production-base">
       <td>[5]</td>
       <td><code>base</code></td>
       <td>::=</td>
-      <td>&quot;@base&quot; <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
+      <td>"<code class="grammar-literal">@base</code>" <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
     </tr>
     <tr id="grammar-production-sparqlPrefix">
       <td>[6]</td>
       <td><code>sparqlPrefix</code></td>
       <td>::=</td>
-      <td>&quot;PREFIX&quot; <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a></td>
+      <td>"<code class="grammar-literal">PREFIX</code>" <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a></td>
     </tr>
     <tr id="grammar-production-sparqlBase">
       <td>[7]</td>
       <td><code>sparqlBase</code></td>
       <td>::=</td>
-      <td>&quot;BASE&quot; <a href="#grammar-production-IRIREF">IRIREF</a></td>
+      <td>"<code class="grammar-literal">BASE</code>" <a href="#grammar-production-IRIREF">IRIREF</a></td>
     </tr>
     <tr id="grammar-production-triples">
       <td>[8]</td>
@@ -114,13 +114,13 @@
       <td>[19]</td>
       <td><code>RDFLiteral</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-String">String</a> <code class="grammar-paren">(</code><a href="#grammar-production-LANGTAG">LANGTAG</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>&quot;^^&quot; <a href="#grammar-production-iri">iri</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td><a href="#grammar-production-String">String</a> <code class="grammar-paren">(</code><a href="#grammar-production-LANGTAG">LANGTAG</a> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">^^</code>" <a href="#grammar-production-iri">iri</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-BooleanLiteral">
       <td>[20]</td>
       <td><code>BooleanLiteral</code></td>
       <td>::=</td>
-      <td>&quot;true&quot; <code class="grammar-alt">|</code> &quot;false&quot;</td>
+      <td>"<code class="grammar-literal">true</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">false</code>"</td>
     </tr>
     <tr id="grammar-production-String">
       <td>[21]</td>
@@ -150,7 +150,7 @@
       <td>[25]</td>
       <td><code>quotedTriple</code></td>
       <td>::=</td>
-      <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-qtSubject">qtSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-qtObject">qtObject</a> &quot;&gt;&gt;&quot;</td>
+      <td>"<code class="grammar-literal">&lt;&lt;</code>" <a href="#grammar-production-qtSubject">qtSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-qtObject">qtObject</a> "<code class="grammar-literal">&gt;&gt;</code>"</td>
     </tr>
     <tr id="grammar-production-qtSubject">
       <td>[26]</td>
@@ -168,7 +168,7 @@
       <td>[28]</td>
       <td><code>annotation</code></td>
       <td>::=</td>
-      <td>&quot;{|&quot; <a href="#grammar-production-predicateObjectList">predicateObjectList</a> &quot;|}&quot;</td>
+      <td>"<code class="grammar-literal">{|</code>" <a href="#grammar-production-predicateObjectList">predicateObjectList</a> "<code class="grammar-literal">|}</code>"</td>
     </tr>
     <tr>
       <td colspan=2>@terminals</td>
@@ -197,7 +197,7 @@
       <td>[33]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
-      <td>&quot;_:&quot; <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
+      <td>"<code class="grammar-literal">_:</code>" <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> "<code class="grammar-literal">.</code>"<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANGTAG">
       <td>[34]</td>
@@ -245,19 +245,19 @@
       <td>[41]</td>
       <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
       <td>::=</td>
-      <td>&quot;&apos;&apos;&apos;&quot; <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> &quot;&apos;&apos;&quot;<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&apos;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> &quot;&apos;&apos;&apos;&quot;</td>
+      <td>"<code class="grammar-literal">&apos;&apos;&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;&apos;</code>"<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&apos;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;&apos;&apos;</code>"</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE">
       <td>[42]</td>
       <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
       <td>::=</td>
-      <td>&apos;&quot;&quot;&quot;&apos; <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">&quot;</code>' <code class="grammar-alt">|</code> &apos;&quot;&quot;&apos;<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&quot;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> &apos;&quot;&quot;&quot;&apos;</td>
+      <td>'<code class="grammar-literal">&quot;&quot;&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">&quot;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&quot;&quot;</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&quot;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;&quot;&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-UCHAR">
       <td>[43]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
-      <td><code class="grammar-paren">(</code>&quot;\u&quot; <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>&quot;\U&quot; <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
+      <td><code class="grammar-paren">(</code>"<code class="grammar-literal">\u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>"<code class="grammar-literal">\U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
       <td>[44]</td>
@@ -291,68 +291,68 @@
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-z</code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-literal">a-z</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr>
       <td colspan=2></td>
-      <td>|</td>
-      <td><code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
+      <td><code class="grammar-alt">|</code></td>
+      <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
       <td>[49]</td>

--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -1,304 +1,406 @@
-<table  class="grammar">
-    <tbody class="grammar-productions">
-            <tr id="grammar-production-turtleDoc" >
-    <td>[1]</td>
-    <td><code>turtleDoc</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-statement'>statement</a><code class='grammar-star'>*</code></td>
-</tr>
-            <tr id="grammar-production-statement" >
-    <td>[2]</td>
-    <td><code>statement</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-directive'>directive</a> <code>| </code> <a href='#grammar-production-triples'>triples</a> '<code class='grammar-literal'>.</code>'</td>
-</tr>
-            <tr id="grammar-production-directive" >
-    <td>[3]</td>
-    <td><code>directive</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-prefixID'>prefixID</a> <code>| </code> <a href='#grammar-production-base'>base</a> <code>| </code> <a href='#grammar-production-sparqlPrefix'>sparqlPrefix</a> <code>| </code> <a href='#grammar-production-sparqlBase'>sparqlBase</a></td>
-</tr>
-            <tr id="grammar-production-prefixID" >
-    <td>[4]</td>
-    <td><code>prefixID</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>@prefix</code>' <a href='#grammar-production-PNAME_NS'>PNAME_NS</a> <a href='#grammar-production-IRIREF'>IRIREF</a> '<code class='grammar-literal'>.</code>'</td>
-</tr>
-            <tr id="grammar-production-base" >
-    <td>[5]</td>
-    <td><code>base</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>@base</code>' <a href='#grammar-production-IRIREF'>IRIREF</a> '<code class='grammar-literal'>.</code>'</td>
-</tr>
-            <tr id="grammar-production-sparqlBase" >
-    <td>[5s]</td>
-    <td><code>sparqlBase</code></td>
-    <td>::=</td>
-    <td><span class="add">"<code class="grammar-literal">BASE</code>"</span> <a href="#grammar-production-IRIREF">IRIREF</a></td>
-</tr>
-            <tr id="grammar-production-sparqlPrefix" >
-    <td>[6s]</td>
-    <td><code>sparqlPrefix</code></td>
-    <td>::=</td>
-    <td><span class="add">"<code class="grammar-literal">PREFIX</code>"</span> <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a></td>
-</tr>
-            <tr id="grammar-production-triples" >
-    <td>[6]</td>
-    <td><code>triples</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-subject'>subject</a> <a href='#grammar-production-predicateObjectList'>predicateObjectList</a> <code>| </code> <a href='#grammar-production-blankNodePropertyList'>blankNodePropertyList</a> <a href='#grammar-production-predicateObjectList'>predicateObjectList</a>?</td>
-</tr>
-            <tr id="grammar-production-predicateObjectList" >
-    <td>[7]</td>
-    <td><code>predicateObjectList</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-verb'>verb</a> <a href='#grammar-production-objectList'>objectList</a> ('<code class='grammar-literal'>;</code>' (<a href='#grammar-production-verb'>verb</a> <a href='#grammar-production-objectList'>objectList</a>)?)<code class='grammar-star'>*</code></td>
-</tr>
-            <tr id="grammar-production-objectList" >
-    <td>[8]</td>
-    <td><code>objectList</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-object'>object</a> ('<code class='grammar-literal'>,</code>' <a href='#grammar-production-object'>object</a>)<code class='grammar-star'>*</code></td>
-</tr>
-            <tr id="grammar-production-verb" >
-    <td>[9]</td>
-    <td><code>verb</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-predicate'>predicate</a> <code>| </code> '<code class='grammar-literal'>a</code>'</td>
-</tr>
-            <tr id="grammar-production-subject" >
-    <td>[10]</td>
-    <td><code>subject</code></td>
-    <td>::=</td>
-    <td><a href="#grammar-production-iri">iri</a> <code>| </code> <a href="#grammar-production-BlankNode" class="add">BlankNode</a> <code class="add">| </code> <a href="#grammar-production-collection" class="add">collection</a></td>
-</tr>
-            <tr id="grammar-production-predicate" >
-    <td>[11]</td>
-    <td><code>predicate</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-iri'>iri</a></td>
-</tr>
-            <tr id="grammar-production-object" >
-    <td>[12]</td>
-    <td><code>object</code></td>
-    <td>::=</td>
-    <td><a href="#grammar-production-iri">iri</a> <code>| </code> <a href="#grammar-production-BlankNode" class="add">BlankNode</a> <code class="add">| </code> <a href="#grammar-production-collection" class="add">collection</a> <code>| </code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code>| </code> <a href="#grammar-production-literal">literal</a></td>
-</tr>
-            <tr id="grammar-production-literal" >
-    <td>[13]</td>
-    <td><code>literal</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-RDFLiteral'>RDFLiteral</a> <code>| </code> <a href='#grammar-production-NumericLiteral'>NumericLiteral</a> <code>| </code> <a href='#grammar-production-BooleanLiteral'>BooleanLiteral</a></td>
-</tr>
-            <tr id="grammar-production-blankNodePropertyList" >
-    <td>[14]</td>
-    <td><code>blankNodePropertyList</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>[</code>' <a href='#grammar-production-predicateObjectList'>predicateObjectList</a> '<code class='grammar-literal'>]</code>'</td>
-</tr>
-            <tr id="grammar-production-collection" >
-    <td>[15]</td>
-    <td><code>collection</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>(</code>' <a href='#grammar-production-object'>object</a><code class='grammar-star'>*</code> '<code class='grammar-literal'>)</code>'</td>
-</tr>
-            <tr id="grammar-production-NumericLiteral" >
-    <td>[16]</td>
-    <td><code>NumericLiteral</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-INTEGER'>INTEGER</a> <code>| </code> <a href='#grammar-production-DECIMAL'>DECIMAL</a> <code>| </code> <a href='#grammar-production-DOUBLE'>DOUBLE</a></td>
-</tr>
-            <tr id="grammar-production-RDFLiteral" >
-    <td>[128s]</td>
-    <td><code>RDFLiteral</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-String'>String</a> (<a href='#grammar-production-LANGTAG'>LANGTAG</a> <code>| </code> '<code class='grammar-literal'>^^</code>' <a href='#grammar-production-iri'>iri</a>)?</td>
-</tr>
-            <tr id="grammar-production-BooleanLiteral" >
-    <td>[133s]</td>
-    <td><code>BooleanLiteral</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>true</code>' <code>| </code> '<code class='grammar-literal'>false</code>'</td>
-</tr>
-            <tr id="grammar-production-String" >
-    <td>[17]</td>
-    <td><code>String</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-STRING_LITERAL_QUOTE'>STRING_LITERAL_QUOTE</a> <code>| </code> <a href='#grammar-production-STRING_LITERAL_SINGLE_QUOTE'>STRING_LITERAL_SINGLE_QUOTE</a> <code>| </code> <a href='#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE'>STRING_LITERAL_LONG_SINGLE_QUOTE</a> <code>| </code> <a href='#grammar-production-STRING_LITERAL_LONG_QUOTE'>STRING_LITERAL_LONG_QUOTE</a></td>
-</tr>
-            <tr id="grammar-production-iri" >
-    <td>[135s]</td>
-    <td><code>iri</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-IRIREF'>IRIREF</a> <code>| </code> <a href='#grammar-production-PrefixedName'>PrefixedName</a></td>
-</tr>
-            <tr id="grammar-production-PrefixedName" >
-    <td>[136s]</td>
-    <td><code>PrefixedName</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PNAME_LN'>PNAME_LN</a> <code>| </code> <a href='#grammar-production-PNAME_NS'>PNAME_NS</a></td>
-</tr>
-            <tr id="grammar-production-BlankNode" >
-    <td>[137s]</td>
-    <td><code>BlankNode</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-BLANK_NODE_LABEL'>BLANK_NODE_LABEL</a> <code>| </code> <a href='#grammar-production-ANON'>ANON</a></td>
-</tr>
-<tr><td colspan="4"><h4 id="terminals">Productions for terminals</h4></td></tr>
-            <tr id="grammar-production-IRIREF" class='grammar-token'>
-    <td>[18]</td>
-    <td><code>IRIREF</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>&lt;</code>' ([<code class='grammar-chars'>^#x00-#x20&lt;&gt;&quot;{}|^`\</code>] <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>)<code class='grammar-star'>*</code> '<code class='grammar-literal'>&gt;</code>'<span class="grammar_comment"> /* #x00=NULL #01-#x1F=control codes #x20=space */</span></td>
-</tr>
-            <tr id="grammar-production-PNAME_NS" class='grammar-token'>
-    <td>[139s]</td>
-    <td><code>PNAME_NS</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PN_PREFIX'>PN_PREFIX</a>? '<code class='grammar-literal'>:</code>'</td>
-</tr>
-            <tr id="grammar-production-PNAME_LN" class='grammar-token'>
-    <td>[140s]</td>
-    <td><code>PNAME_LN</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PNAME_NS'>PNAME_NS</a> <a href='#grammar-production-PN_LOCAL'>PN_LOCAL</a></td>
-</tr>
-            <tr id="grammar-production-BLANK_NODE_LABEL" class='grammar-token'>
-    <td>[141s]</td>
-    <td><code>BLANK_NODE_LABEL</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>_:</code>' (<a href='#grammar-production-PN_CHARS_U'>PN_CHARS_U</a> <code>| </code> [<code class='grammar-chars'>0-9</code>]) ((<a href='#grammar-production-PN_CHARS'>PN_CHARS</a> <code>| </code> '<code class='grammar-literal'>.</code>')<code class='grammar-star'>*</code> <a href='#grammar-production-PN_CHARS'>PN_CHARS</a>)?</td>
-</tr>
-            <tr id="grammar-production-LANGTAG" class='grammar-token'>
-    <td>[144s]</td>
-    <td><code>LANGTAG</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>@</code>' [<code class='grammar-chars'>a-zA-Z</code>]<code class='grammar-plus'>+</code> ('<code class='grammar-literal'>-</code>' [<code class='grammar-chars'>a-zA-Z0-9</code>]<code class='grammar-plus'>+</code>)<code class='grammar-star'>*</code></td>
-</tr>
-            <tr id="grammar-production-INTEGER" class='grammar-token'>
-    <td>[19]</td>
-    <td><code>INTEGER</code></td>
-    <td>::=</td>
-    <td>[<code class='grammar-chars'>+-</code>]? [<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code></td>
-</tr>
-            <tr id="grammar-production-DECIMAL" class='grammar-token'>
-    <td>[20]</td>
-    <td><code>DECIMAL</code></td>
-    <td>::=</td>
-    <td>[<code class='grammar-chars'>+-</code>]? [<code class='grammar-chars'>0-9</code>]<code class='grammar-star'>*</code> '<code class='grammar-literal'>.</code>' [<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code></td>
-</tr>
-            <tr id="grammar-production-DOUBLE" class='grammar-token'>
-    <td>[21]</td>
-    <td><code>DOUBLE</code></td>
-    <td>::=</td>
-    <td>[<code class='grammar-chars'>+-</code>]? ([<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code> '<code class='grammar-literal'>.</code>' [<code class='grammar-chars'>0-9</code>]<code class='grammar-star'>*</code> <a href='#grammar-production-EXPONENT'>EXPONENT</a> <code>| </code> '<code class='grammar-literal'>.</code>' [<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code> <a href='#grammar-production-EXPONENT'>EXPONENT</a> <code>| </code> [<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code> <a href='#grammar-production-EXPONENT'>EXPONENT</a>)</td>
-</tr>
-            <tr id="grammar-production-EXPONENT" class='grammar-token'>
-    <td>[154s]</td>
-    <td><code>EXPONENT</code></td>
-    <td>::=</td>
-    <td>[<code class='grammar-chars'>eE</code>] [<code class='grammar-chars'>+-</code>]? [<code class='grammar-chars'>0-9</code>]<code class='grammar-plus'>+</code></td>
-</tr>
-            <tr id="grammar-production-STRING_LITERAL_QUOTE" class='grammar-token'>
-    <td>[22]</td>
-    <td><code>STRING_LITERAL_QUOTE</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>&quot;</code>' ([<code class='grammar-chars'>^#x22#x5C#xA#xD</code>] <code>| </code> <a href='#grammar-production-ECHAR'>ECHAR</a> <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>)<code class='grammar-star'>*</code> '<code class='grammar-literal'>&quot;</code>'<span class="grammar_comment"> /* #x22=" #x5C=\ #xA=new line #xD=carriage return */</span></td>
-</tr>
-            <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE" class='grammar-token'>
-    <td>[23]</td>
-    <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
-    <td>::=</td>
-    <td>"<code class="grammar-literal">&#x27;</code>" ([<code class='grammar-chars'>^#x27#x5C#xA#xD</code>] <code>| </code> <a href='#grammar-production-ECHAR'>ECHAR</a> <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>)<code class='grammar-star'>*</code> "<code class="grammar-literal">&#x27;</code>"<span class="grammar_comment"> /* #x27=' #x5C=\ #xA=new line #xD=carriage return */</span></td>
-</tr>
-            <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE" class='grammar-token'>
-    <td>[24]</td>
-    <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
-    <td>::=</td>
-    <td>"<code class="grammar-literal">&#x27;&#x27;&#x27;</code>" (("<code class="grammar-literal">&#x27;</code>" <code>| </code> "<code class="grammar-literal">&#x27;&#x27;</code>")? ([<code class='grammar-chars'>^&#x27;\</code>] <code>| </code> <a href='#grammar-production-ECHAR'>ECHAR</a> <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>))<code class='grammar-star'>*</code> "<code class="grammar-literal">&#x27;&#x27;&#x27;</code>"</td>
-</tr>
-            <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE" class='grammar-token'>
-    <td>[25]</td>
-    <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>&quot;&quot;&quot;</code>' (('<code class='grammar-literal'>&quot;</code>' <code>| </code> '<code class='grammar-literal'>&quot;&quot;</code>')? ([<code class='grammar-chars'>^&quot;\</code>] <code>| </code> <a href='#grammar-production-ECHAR'>ECHAR</a> <code>| </code> <a href='#grammar-production-UCHAR'>UCHAR</a>))<code class='grammar-star'>*</code> '<code class='grammar-literal'>&quot;&quot;&quot;</code>'</td>
-</tr>
-            <tr id="grammar-production-UCHAR" class='grammar-token'>
-    <td>[26]</td>
-    <td><code>UCHAR</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>\u</code>' <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <code>| </code> '<code class='grammar-literal'>\U</code>' <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a></td>
-</tr>
-            <tr id="grammar-production-ECHAR" class='grammar-token'>
-    <td>[159s]</td>
-    <td><code>ECHAR</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>\</code>' [<code class='grammar-chars'>tbnrf&quot;&#x27;\</code>]</td>
-</tr>
-            <tr id="grammar-production-WS" class='grammar-token'>
-    <td>[161s]</td>
-    <td><code>WS</code></td>
-    <td>::=</td>
-    <td><code class='grammar-char-escape'>#x20</code> <code>| </code> <code class='grammar-char-escape'>#x9</code> <code>| </code> <code class='grammar-char-escape'>#xD</code> <code>| </code> <code class='grammar-char-escape'>#xA</code><span class="grammar_comment"> /* #x20=space #x9=character tabulation #xD=carriage return #xA=new line */</span></td>
-</tr>
-            <tr id="grammar-production-ANON" class='grammar-token'>
-    <td>[162s]</td>
-    <td><code>ANON</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>[</code>' <a href='#grammar-production-WS'>WS</a><code class='grammar-star'>*</code> '<code class='grammar-literal'>]</code>'</td>
-</tr>
-            <tr id="grammar-production-PN_CHARS_BASE" class='grammar-token'>
-    <td>[163s]</td>
-    <td><code>PN_CHARS_BASE</code></td>
-    <td>::=</td>
-    <td>[<code class="grammar-chars">A-Z</code>] <code>| </code> [<code class="grammar-chars">a-z</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>00C0-#<span class="add">x</span>00D6</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>00D8-#<span class="add">x</span>00F6</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>00F8-#<span class="add">x</span>02FF</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>0370-#<span class="add">x</span>037D</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>037F-#<span class="add">x</span>1FFF</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>200C-#<span class="add">x</span>200D</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>2070-#<span class="add">x</span>218F</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>2C00-#<span class="add">x</span>2FEF</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>3001-#<span class="add">x</span>D7FF</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>F900-#<span class="add">x</span>FDCF</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>FDF0-#<span class="add">x</span>FFFD</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>10000-#<span class="add">x</span>EFFFF</code>]</td>
-</tr>
-            <tr id="grammar-production-PN_CHARS_U" class='grammar-token'>
-    <td>[164s]</td>
-    <td><code>PN_CHARS_U</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> <code>| </code> '<code class='grammar-literal'>_</code>'</td>
-</tr>
-            <tr id="grammar-production-PN_CHARS" class='grammar-token'>
-    <td>[166s]</td>
-    <td><code>PN_CHARS</code></td>
-    <td>::=</td>
-    <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>| </code> '<code class="grammar-literal">-</code>' <code>| </code> [<code class="grammar-chars">0-9</code>] <code>| </code> <code class="grammar-char-escape">#<span class="add">x</span>00B7</code> <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>0300-#<span class="add">x</span>036F</code>] <code>| </code> [<code class="grammar-chars">#<span class="add">x</span>203F-#<span class="add">x</span>2040</code>]</td>
-</tr>
-            <tr id="grammar-production-PN_PREFIX" class='grammar-token'>
-    <td>[167s]</td>
-    <td><code>PN_PREFIX</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PN_CHARS_BASE'>PN_CHARS_BASE</a> ((<a href='#grammar-production-PN_CHARS'>PN_CHARS</a> <code>| </code> '<code class='grammar-literal'>.</code>')<code class='grammar-star'>*</code> <a href='#grammar-production-PN_CHARS'>PN_CHARS</a>)?</td>
-</tr>
-            <tr id="grammar-production-PN_LOCAL" class='grammar-token'>
-    <td>[168s]</td>
-    <td><code>PN_LOCAL</code></td>
-    <td>::=</td>
-    <td>(<a href='#grammar-production-PN_CHARS_U'>PN_CHARS_U</a> <code>| </code> '<code class='grammar-literal'>:</code>' <code>| </code> [<code class='grammar-chars'>0-9</code>] <code>| </code> <a href='#grammar-production-PLX'>PLX</a>) ((<a href='#grammar-production-PN_CHARS'>PN_CHARS</a> <code>| </code> '<code class='grammar-literal'>.</code>' <code>| </code> '<code class='grammar-literal'>:</code>' <code>| </code> <a href='#grammar-production-PLX'>PLX</a>)<code class='grammar-star'>*</code> (<a href='#grammar-production-PN_CHARS'>PN_CHARS</a> <code>| </code> '<code class='grammar-literal'>:</code>' <code>| </code> <a href='#grammar-production-PLX'>PLX</a>))?</td>
-</tr>
-            <tr id="grammar-production-PLX" class='grammar-token'>
-    <td>[169s]</td>
-    <td><code>PLX</code></td>
-    <td>::=</td>
-    <td><a href='#grammar-production-PERCENT'>PERCENT</a> <code>| </code> <a href='#grammar-production-PN_LOCAL_ESC'>PN_LOCAL_ESC</a></td>
-</tr>
-            <tr id="grammar-production-PERCENT" class='grammar-token'>
-    <td>[170s]</td>
-    <td><code>PERCENT</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>%</code>' <a href='#grammar-production-HEX'>HEX</a> <a href='#grammar-production-HEX'>HEX</a></td>
-</tr>
-            <tr id="grammar-production-HEX" class='grammar-token'>
-    <td>[171s]</td>
-    <td><code>HEX</code></td>
-    <td>::=</td>
-    <td>[<code class='grammar-chars'>0-9</code>] <code>| </code> [<code class='grammar-chars'>A-F</code>] <code>| </code> [<code class='grammar-chars'>a-f</code>]</td>
-</tr>
-            <tr id="grammar-production-PN_LOCAL_ESC" class='grammar-token'>
-    <td>[172s]</td>
-    <td><code>PN_LOCAL_ESC</code></td>
-    <td>::=</td>
-    <td>'<code class='grammar-literal'>\</code>' ('<code class='grammar-literal'>_</code>' <code>| </code> '<code class='grammar-literal'>~</code>' <code>| </code> '<code class='grammar-literal'>.</code>' <code>| </code> '<code class='grammar-literal'>-</code>' <code>| </code> '<code class='grammar-literal'>!</code>' <code>| </code> '<code class='grammar-literal'>$</code>' <code>| </code> '<code class='grammar-literal'>&amp;</code>' <code>| </code> "<code class="grammar-literal">&#x27;</code>" <code>| </code> '<code class='grammar-literal'>(</code>' <code>| </code> '<code class='grammar-literal'>)</code>' <code>| </code> '<code class='grammar-literal'>*</code>' <code>| </code> '<code class='grammar-literal'>+</code>' <code>| </code> '<code class='grammar-literal'>,</code>' <code>| </code> '<code class='grammar-literal'>;</code>' <code>| </code> '<code class='grammar-literal'>=</code>' <code>| </code> '<code class='grammar-literal'>/</code>' <code>| </code> '<code class='grammar-literal'>?</code>' <code>| </code> '<code class='grammar-literal'>#</code>' <code>| </code> '<code class='grammar-literal'>@</code>' <code>| </code> '<code class='grammar-literal'>%</code>')</td>
-</tr>
+
+<table class="grammar">
+  <tbody id="grammar-productions" class="ebnf">
+    <tr id="grammar-production-turtleDoc">
+      <td>[1]</td>
+      <td><code>turtleDoc</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-statement">statement</a><code>*</code> </td>
+    </tr>
+    <tr id="grammar-production-statement">
+      <td>[2]</td>
+      <td><code>statement</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-directive">directive</a> <code>|</code> <code>(</code> <a href="#grammar-production-triples">triples</a> "<code class="grammar-literal">.</code>"<code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-directive">
+      <td>[3]</td>
+      <td><code>directive</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-prefixID">prefixID</a> <code>|</code> <a href="#grammar-production-base">base</a> <code>|</code> <a href="#grammar-production-sparqlPrefix">sparqlPrefix</a> <code>|</code> <a href="#grammar-production-sparqlBase">sparqlBase</a></td>
+    </tr>
+    <tr id="grammar-production-prefixID">
+      <td>[4]</td>
+      <td><code>prefixID</code></td>
+      <td>::=</td>
+      <td>&quot;@prefix&quot; <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
+    </tr>
+    <tr id="grammar-production-base">
+      <td>[5]</td>
+      <td><code>base</code></td>
+      <td>::=</td>
+      <td>&quot;@base&quot; <a href="#grammar-production-IRIREF">IRIREF</a> "<code class="grammar-literal">.</code>"</td>
+    </tr>
+    <tr id="grammar-production-sparqlPrefix">
+      <td>[6]</td>
+      <td><code>sparqlPrefix</code></td>
+      <td>::=</td>
+      <td>&quot;PREFIX&quot; <a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-IRIREF">IRIREF</a></td>
+    </tr>
+    <tr id="grammar-production-sparqlBase">
+      <td>[7]</td>
+      <td><code>sparqlBase</code></td>
+      <td>::=</td>
+      <td>&quot;BASE&quot; <a href="#grammar-production-IRIREF">IRIREF</a></td>
+    </tr>
+    <tr id="grammar-production-triples">
+      <td>[8]</td>
+      <td><code>triples</code></td>
+      <td>::=</td>
+      <td><code>(</code> <a href="#grammar-production-subject">subject</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code>)</code>  <code>|</code> <code>(</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <a href="#grammar-production-predicateObjectList">predicateObjectList</a><code>?</code> <code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-predicateObjectList">
+      <td>[9]</td>
+      <td><code>predicateObjectList</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a> <code>(</code> "<code class="grammar-literal">;</code>" <code>(</code> <a href="#grammar-production-verb">verb</a> <a href="#grammar-production-objectList">objectList</a><code>)</code> <code>?</code> <code>)</code> <code>*</code> </td>
+    </tr>
+    <tr id="grammar-production-objectList">
+      <td>[10]</td>
+      <td><code>objectList</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code>?</code>  <code>(</code> "<code class="grammar-literal">,</code>" <a href="#grammar-production-object">object</a> <a href="#grammar-production-annotation">annotation</a><code>?</code> <code>)</code> <code>*</code> </td>
+    </tr>
+    <tr id="grammar-production-verb">
+      <td>[11]</td>
+      <td><code>verb</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-predicate">predicate</a> <code>|</code> "<code class="grammar-literal">a</code>"</td>
+    </tr>
+    <tr id="grammar-production-subject">
+      <td>[12]</td>
+      <td><code>subject</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-collection">collection</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+    </tr>
+    <tr id="grammar-production-predicate">
+      <td>[13]</td>
+      <td><code>predicate</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a></td>
+    </tr>
+    <tr id="grammar-production-object">
+      <td>[14]</td>
+      <td><code>object</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-collection">collection</a> <code>|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code>|</code> <a href="#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+    </tr>
+    <tr id="grammar-production-literal">
+      <td>[15]</td>
+      <td><code>literal</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-RDFLiteral">RDFLiteral</a> <code>|</code> <a href="#grammar-production-NumericLiteral">NumericLiteral</a> <code>|</code> <a href="#grammar-production-BooleanLiteral">BooleanLiteral</a></td>
+    </tr>
+    <tr id="grammar-production-blankNodePropertyList">
+      <td>[16]</td>
+      <td><code>blankNodePropertyList</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">[</code>" <a href="#grammar-production-predicateObjectList">predicateObjectList</a> "<code class="grammar-literal">]</code>"</td>
+    </tr>
+    <tr id="grammar-production-collection">
+      <td>[17]</td>
+      <td><code>collection</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-object">object</a><code>*</code>  "<code class="grammar-literal">)</code>"</td>
+    </tr>
+    <tr id="grammar-production-NumericLiteral">
+      <td>[18]</td>
+      <td><code>NumericLiteral</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-INTEGER">INTEGER</a> <code>|</code> <a href="#grammar-production-DECIMAL">DECIMAL</a> <code>|</code> <a href="#grammar-production-DOUBLE">DOUBLE</a></td>
+    </tr>
+    <tr id="grammar-production-RDFLiteral">
+      <td>[19]</td>
+      <td><code>RDFLiteral</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-String">String</a> <code>(</code> <a href="#grammar-production-LANGTAG">LANGTAG</a> <code>|</code> <code>(</code> &quot;^^&quot; <a href="#grammar-production-iri">iri</a><code>)</code> <code>)</code> <code>?</code> </td>
+    </tr>
+    <tr id="grammar-production-BooleanLiteral">
+      <td>[20]</td>
+      <td><code>BooleanLiteral</code></td>
+      <td>::=</td>
+      <td>&quot;true&quot; <code>|</code> &quot;false&quot;</td>
+    </tr>
+    <tr id="grammar-production-String">
+      <td>[21]</td>
+      <td><code>String</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-STRING_LITERAL_QUOTE">STRING_LITERAL_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_SINGLE_QUOTE">STRING_LITERAL_SINGLE_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">STRING_LITERAL_LONG_SINGLE_QUOTE</a> <code>|</code> <a href="#grammar-production-STRING_LITERAL_LONG_QUOTE">STRING_LITERAL_LONG_QUOTE</a></td>
+    </tr>
+    <tr id="grammar-production-iri">
+      <td>[22]</td>
+      <td><code>iri</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-IRIREF">IRIREF</a> <code>|</code> <a href="#grammar-production-PrefixedName">PrefixedName</a></td>
+    </tr>
+    <tr id="grammar-production-PrefixedName">
+      <td>[23]</td>
+      <td><code>PrefixedName</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PNAME_LN">PNAME_LN</a> <code>|</code> <a href="#grammar-production-PNAME_NS">PNAME_NS</a></td>
+    </tr>
+    <tr id="grammar-production-BlankNode">
+      <td>[24]</td>
+      <td><code>BlankNode</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code>|</code> <a href="#grammar-production-ANON">ANON</a></td>
+    </tr>
+    <tr id="grammar-production-quotedTriple">
+      <td>[25]</td>
+      <td><code>quotedTriple</code></td>
+      <td>::=</td>
+      <td>&quot;&lt;&lt;&quot; <a href="#grammar-production-qtSubject">qtSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-qtObject">qtObject</a> &quot;&gt;&gt;&quot;</td>
+    </tr>
+    <tr id="grammar-production-qtSubject">
+      <td>[26]</td>
+      <td><code>qtSubject</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+    </tr>
+    <tr id="grammar-production-qtObject">
+      <td>[27]</td>
+      <td><code>qtObject</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code>|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code>|</code> <a href="#grammar-production-literal">literal</a> <code>|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+    </tr>
+    <tr id="grammar-production-annotation">
+      <td>[28]</td>
+      <td><code>annotation</code></td>
+      <td>::=</td>
+      <td>&quot;{|&quot; <a href="#grammar-production-predicateObjectList">predicateObjectList</a> &quot;|}&quot;</td>
+    </tr>
+    <tr>
+      <td colspan=2>@terminals</td>
+      <td></td>
+      <td><strong># Productions for terminals</strong></td>
+    </tr>
+    <tr id="grammar-production-IRIREF">
+      <td>[30]</td>
+      <td><code>IRIREF</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">&lt;</code>" <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&apos;&gt;&apos;</code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-PNAME_NS">
+      <td>[31]</td>
+      <td><code>PNAME_NS</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PN_PREFIX">PN_PREFIX</a><code>?</code>  "<code class="grammar-literal">:</code>"</td>
+    </tr>
+    <tr id="grammar-production-PNAME_LN">
+      <td>[32]</td>
+      <td><code>PNAME_LN</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-PN_LOCAL">PN_LOCAL</a></td>
+    </tr>
+    <tr id="grammar-production-BLANK_NODE_LABEL">
+      <td>[33]</td>
+      <td><code>BLANK_NODE_LABEL</code></td>
+      <td>::=</td>
+      <td>&quot;_:&quot; <code>(</code> <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>)</code>  <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>"<code>)</code> <code>*</code>  <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code>)</code> <code>?</code> </td>
+    </tr>
+    <tr id="grammar-production-LANGTAG">
+      <td>[34]</td>
+      <td><code>LANGTAG</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">@</code>" <code>[</code> <code class="grammar-literal">a-zA-Z</code><code>]</code> <code>+</code>  <code>(</code> "<code class="grammar-literal">-</code>" <code>[</code> <code class="grammar-literal">a-zA-Z0-9</code><code>]</code> <code>+</code> <code>)</code> <code>*</code> </td>
+    </tr>
+    <tr id="grammar-production-INTEGER">
+      <td>[35]</td>
+      <td><code>INTEGER</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> </td>
+    </tr>
+    <tr id="grammar-production-DECIMAL">
+      <td>[36]</td>
+      <td><code>DECIMAL</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>*</code>  "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> <code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-DOUBLE">
+      <td>[37]</td>
+      <td><code>DOUBLE</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>(</code> <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>*</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code>  <code>|</code> <code>(</code> "<code class="grammar-literal">.</code>" <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code>  <code>|</code> <code>(</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code>  <a href="#grammar-production-EXPONENT">EXPONENT</a><code>)</code> <code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-EXPONENT">
+      <td>[38]</td>
+      <td><code>EXPONENT</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">eE</code><code>]</code>  <code>[</code> <code class="grammar-literal">+-</code><code>]</code> <code>?</code>  <code>[</code> <code class="grammar-literal">0-9</code><code>]</code> <code>+</code> </td>
+    </tr>
+    <tr id="grammar-production-STRING_LITERAL_QUOTE">
+      <td>[39]</td>
+      <td><code>STRING_LITERAL_QUOTE</code></td>
+      <td>::=</td>
+      <td>'<code class="grammar-literal">&quot;</code>' <code>(</code> <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code>]</code>  <code>|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  '<code class="grammar-literal">&quot;</code>'</td>
+    </tr>
+    <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE">
+      <td>[40]</td>
+      <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">&apos;</code>" <code>(</code> <code>[</code> <code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="ascii '&apos;'">#x27</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code>]</code>  <code>|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code>|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code>)</code> <code>*</code>  "<code class="grammar-literal">&apos;</code>"</td>
+    </tr>
+    <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">
+      <td>[41]</td>
+      <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
+      <td>::=</td>
+      <td>&quot;&apos;&apos;&apos;&quot; <code>(</code> <code>(</code> "<code class="grammar-literal">&apos;</code>" <code>|</code> &quot;&apos;&apos;&quot;<code>)</code> <code>?</code>  <code>[</code> <code class="grammar-literal">^&apos;]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">ECHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&quot;&apos;&apos;&apos;&quot;</code><code>]</code> <code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE">
+      <td>[42]</td>
+      <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
+      <td>::=</td>
+      <td>&apos;&quot;&quot;&quot;&apos; <code>(</code> <code>(</code> '<code class="grammar-literal">&quot;</code>' <code>|</code> &apos;&quot;&quot;&apos;<code>)</code> <code>?</code>  <code>[</code> <code class="grammar-literal">^&quot;]</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">ECHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">|</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">UCHAR</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">)*</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&apos;&quot;&quot;&quot;&apos;</code><code>]</code> <code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-UCHAR">
+      <td>[43]</td>
+      <td><code>UCHAR</code></td>
+      <td>::=</td>
+      <td><code>(</code> "<code class="grammar-literal">u</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code>  <code>|</code> <code>(</code> "<code class="grammar-literal">U</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code>)</code> </td>
+    </tr>
+    <tr id="grammar-production-ECHAR">
+      <td>[44]</td>
+      <td><code>ECHAR</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">\</code>" <code>[</code> <code class="grammar-literal">tbnrf&quot;&apos;</code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-NIL">
+      <td>[45]</td>
+      <td><code>NIL</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">(</code>" <a href="#grammar-production-WS">WS</a><code>*</code>  "<code class="grammar-literal">)</code>"</td>
+    </tr>
+    <tr id="grammar-production-WS">
+      <td>[46]</td>
+      <td><code>WS</code></td>
+      <td>::=</td>
+      <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code>|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
+    </tr>
+    <tr id="grammar-production-ANON">
+      <td>[47]</td>
+      <td><code>ANON</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">[</code>" <a href="#grammar-production-WS">WS</a><code>*</code>  "<code class="grammar-literal">]</code>"</td>
+    </tr>
+    <tr id="grammar-production-PN_CHARS_BASE">
+      <td>[48]</td>
+      <td><code>PN_CHARS_BASE</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">A-Z</code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-literal">a-z</code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xC0'">#xC0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xD6'">#xD6</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xD8'">#xD8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="extended ascii '#xF6'">#xF6</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xF8'">#xF8</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x02FF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0370</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037D</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x037F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x1FFF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200C</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Format'">#x200D</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2070</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x218F</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2C00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#x2FEF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x3001</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Reserved'">#xD7FF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xF900</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDCF</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFDF0</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#xFFFD</abbr></code><code>]</code></td>
+    </tr>
+    <tr>
+      <td colspan=2></td>
+      <td>|</td>
+      <td><code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Noncharacter'">#x000EFFFF</abbr></code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-PN_CHARS_U">
+      <td>[49]</td>
+      <td><code>PN_CHARS_U</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code>|</code> "<code class="grammar-literal">_</code>"</td>
+    </tr>
+    <tr id="grammar-production-PN_CHARS">
+      <td>[50]</td>
+      <td><code>PN_CHARS</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> "<code class="grammar-literal">-</code>" <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code class="grammar-char-escape"><abbr title="extended ascii '#xB7'">#xB7</abbr></code> <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x036F</abbr></code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode 'Graphic'">#x2040</abbr></code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-PN_PREFIX">
+      <td>[51]</td>
+      <td><code>PN_PREFIX</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>"<code>)</code> <code>*</code>  <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code>)</code> <code>?</code> </td>
+    </tr>
+    <tr id="grammar-production-PN_LOCAL">
+      <td>[52]</td>
+      <td><code>PN_LOCAL</code></td>
+      <td>::=</td>
+      <td><code>(</code> <a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code>  <code>(</code> <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">.</code>" <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code> <code>*</code>  <code>(</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code>|</code> "<code class="grammar-literal">:</code>" <code>|</code> <a href="#grammar-production-PLX">PLX</a><code>)</code> <code>)</code> <code>?</code> </td>
+    </tr>
+    <tr id="grammar-production-PLX">
+      <td>[53]</td>
+      <td><code>PLX</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-PERCENT">PERCENT</a> <code>|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
+    </tr>
+    <tr id="grammar-production-PERCENT">
+      <td>[54]</td>
+      <td><code>PERCENT</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">%</code>" <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a></td>
+    </tr>
+    <tr id="grammar-production-HEX">
+      <td>[55]</td>
+      <td><code>HEX</code></td>
+      <td>::=</td>
+      <td><code>[</code> <code class="grammar-literal">0-9</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">A-F</code><code>]</code>  <code>|</code> <code>[</code> <code class="grammar-literal">a-f</code><code>]</code> </td>
+    </tr>
+    <tr id="grammar-production-PN_LOCAL_ESC">
+      <td>[56]</td>
+      <td><code>PN_LOCAL_ESC</code></td>
+      <td>::=</td>
+      <td>"<code class="grammar-literal">\</code>" <code>(</code> "<code class="grammar-literal">_</code>" <code>|</code> "<code class="grammar-literal">~</code>" <code>|</code> "<code class="grammar-literal">.</code>" <code>|</code> "<code class="grammar-literal">-</code>" <code>|</code> "<code class="grammar-literal">!</code>" <code>|</code> "<code class="grammar-literal">$</code>" <code>|</code> "<code class="grammar-literal">&amp;</code>" <code>|</code> "<code class="grammar-literal">&apos;</code>" <code>|</code> "<code class="grammar-literal">(</code>" <code>|</code> "<code class="grammar-literal">)</code>" <code>|</code> "<code class="grammar-literal">*</code>" <code>|</code> "<code class="grammar-literal">+</code>" <code>|</code> "<code class="grammar-literal">,</code>" <code>|</code> "<code class="grammar-literal">;</code>" <code>|</code> "<code class="grammar-literal">=</code>" <code>|</code> "<code class="grammar-literal">/</code>" <code>|</code> "<code class="grammar-literal">?</code>" <code>|</code> "<code class="grammar-literal">#</code>" <code>|</code> "<code class="grammar-literal">@</code>" <code>|</code> "<code class="grammar-literal">%</code>"<code>)</code> </td>
+    </tr>
+  </tbody>
 </table>
+    

--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -179,7 +179,8 @@
       <td>[30]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&lt;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&gt;</code>"</td>
+      <td>"<code class="grammar-literal">&lt;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&gt;</code>"
+        <br/><span class="grammar_comment">/* #x00=NULL #x01-#x1F=control codes #x20=space */</span></td>
     </tr>
     <tr id="grammar-production-PNAME_NS">
       <td>[31]</td>
@@ -233,13 +234,17 @@
       <td>[39]</td>
       <td><code>STRING_LITERAL_QUOTE</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'</td>
+      <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="quot">>&quot;</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'
+        <br/><span class="grammar_comment">/* #x22=" #x5C=\ #xA=new line #xD=carriage return */</span>
+      </td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE">
       <td>[40]</td>
       <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
       <td>::=</td>
-      <td>"<code class="grammar-literal">&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="ascii '&apos;'">#x27</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;</code>"</td>
+      <td>"<code class="grammar-literal">&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="ascii '&apos;'">#x27</abbr></code><code class="grammar-char-escape"><abbr title="ascii '\'">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;</code>"
+        <br/><span class="grammar_comment">/* #x27=' #x5C=\ #xA=new line #xD=carriage return */</span>
+      </td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">
       <td>[41]</td>
@@ -275,7 +280,9 @@
       <td>[46]</td>
       <td><code>WS</code></td>
       <td>::=</td>
-      <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code></td>
+      <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code>
+        <br/><span class="grammar_comment">/* #x20=space #x09=character tabulation #x0D=carriage return #x0A=new line */</span>
+      </td>
     </tr>
     <tr id="grammar-production-ANON">
       <td>[47]</td>

--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -170,10 +170,10 @@
       <td>::=</td>
       <td>"<code class="grammar-literal">{|</code>" <a href="#grammar-production-predicateObjectList">predicateObjectList</a> "<code class="grammar-literal">|}</code>"</td>
     </tr>
-    <tr>
-      <td colspan=2>@terminals</td>
-      <td></td>
-      <td><strong># Productions for terminals</strong></td>
+    <tr id="grammar-declaration-terminals">
+      <td colspan="4">
+        <h3 id="terminals">Productions for terminals</h3>
+      </td>
     </tr>
     <tr id="grammar-production-IRIREF">
       <td>[30]</td>

--- a/spec/turtle.bnf
+++ b/spec/turtle.bnf
@@ -1,126 +1,77 @@
-[1] turtleDoc ::= statement* 
- 
-[2] statement ::= directive 
- | triples "." 
-[3] directive ::= prefixID 
- | base | sparqlPrefix | sparqlBase
-[4] prefixID ::= '@prefix' PNAME_NS IRIREF "."
- 
-[5] base ::= '@base' IRIREF "."
-
-[28*] sparqlPrefix ::= [Pp][Rr][Ee][Ff][Ii][Xx] PNAME_NS IRIREF
-[29*] sparqlBase ::= [Bb][Aa][Ss][Ee] IRIREF
- 
-[6] triples ::= subject predicateObjectList |
-blankNodePropertyList predicateObjectList? 
- 
-[7] predicateObjectList ::= verb objectList (';' (verb objectList)? )*
- 
-[8] objectList ::= object ( "," object )* 
- 
-[9] verb ::= predicate 
- | "a" 
-[10] subject ::= iri 
- | blank 
-[11] predicate ::= iri 
- 
-[12] object ::= iri 
- | blank 
- | blankNodePropertyList
- | literal 
-[13] literal ::= RDFLiteral 
- | NumericLiteral 
- | BooleanLiteral 
-[14] blank ::= BlankNode 
- | collection 
-[15] blankNodePropertyList ::= "[" predicateObjectList "]" 
- 
-[16] collection ::= "(" object* ")" 
-[17] NumericLiteral ::= INTEGER | DECIMAL | DOUBLE 
-
-[128s] RDFLiteral ::= String ( LANGTAG | ( "^^" iri ) )? 
- 
-[133s] BooleanLiteral ::= "true" 
- | "false" 
-[18] String ::= STRING_LITERAL_QUOTE 
- | STRING_LITERAL_SINGLE_QUOTE 
- | STRING_LITERAL_LONG_SINGLE_QUOTE 
- | STRING_LITERAL_LONG_QUOTE 
-[135s] iri ::= IRIREF 
- | PrefixedName 
-[136s] PrefixedName ::= PNAME_LN 
- | PNAME_NS 
-[137s] BlankNode ::= BLANK_NODE_LABEL 
- | ANON 
+turtleDoc             ::= statement* 
+statement             ::= directive | triples "." 
+directive             ::= prefixID | base | sparqlPrefix | sparqlBase
+prefixID              ::= '@prefix' PNAME_NS IRIREF "."
+base                  ::= '@base' IRIREF "."
+sparqlPrefix          ::=	"PREFIX" PNAME_NS IRIREF
+sparqlBase            ::=	"BASE" IRIREF
+triples               ::= subject predicateObjectList | blankNodePropertyList predicateObjectList? 
+predicateObjectList   ::= verb objectList (';' (verb objectList)? )*
+objectList            ::= object annotation? ( ',' object annotation? )* 
+verb                  ::= predicate | "a" 
+subject               ::= iri | BlankNode | collection | quotedTriple
+predicate             ::= iri
+object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | quotedTriple 
+literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral 
+blankNodePropertyList ::= "[" predicateObjectList "]" 
+collection            ::= "(" object* ")" 
+NumericLiteral        ::= INTEGER | DECIMAL | DOUBLE 
+RDFLiteral            ::= String ( LANGTAG | ( "^^" iri ) )? 
+BooleanLiteral        ::= "true" | "false" 
+String                ::= STRING_LITERAL_QUOTE | STRING_LITERAL_SINGLE_QUOTE
+                        | STRING_LITERAL_LONG_SINGLE_QUOTE | STRING_LITERAL_LONG_QUOTE 
+iri                   ::= IRIREF | PrefixedName 
+PrefixedName          ::= PNAME_LN | PNAME_NS 
+BlankNode             ::= BLANK_NODE_LABEL | ANON 
+quotedTriple          ::= '<<' qtSubject predicate qtObject '>>'
+qtSubject             ::=	iri | BlankNode | quotedTriple
+qtObject              ::=	iri | BlankNode | literal | quotedTriple
+annotation            ::= '{|' predicateObjectList '|}'
 
 @terminals
 
-[19] IRIREF ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
- 
-[139s] PNAME_NS ::= PN_PREFIX? ":" 
- 
-[140s] PNAME_LN ::= PNAME_NS PN_LOCAL 
- 
-[141s] BLANK_NODE_LABEL ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
- 
-[144s] LANGTAG ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* 
-[20] INTEGER ::= [+-]? [0-9]+
- 
-[21] DECIMAL ::= [+-]?  ( ([0-9])* '.' ([0-9])+  )
-[22] DOUBLE ::= [+-]? ( [0-9]+ '.' [0-9]* EXPONENT | '.' ([0-9])+ EXPONENT | ([0-9])+ 
-EXPONENT )
-  
-[154s] EXPONENT ::= [eE] [+-]? [0-9]+ 
- 
-[23] STRING_LITERAL_QUOTE ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"' 
- 
-[24] STRING_LITERAL_SINGLE_QUOTE ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'" 
- 
-[25] STRING_LITERAL_LONG_SINGLE_QUOTE ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''" 
- 
-[26] STRING_LITERAL_LONG_QUOTE ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""' 
- 
-[27] UCHAR ::= ( "\u" HEX HEX HEX HEX ) 
- | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX ) 
-
-[159s] ECHAR ::= "\" [tbnrf\"'] 
- 
-[160s] NIL ::= "(" WS* ")" 
- 
-[161s] WS ::= #x20 | #x9 | #xD | #xA
-
-[162s] ANON ::= "[" WS* "]" 
- 
-[163s] PN_CHARS_BASE ::= [A-Z] 
- | [a-z] 
- | [#00C0-#00D6] 
- | [#00D8-#00F6] 
- | [#00F8-#02FF] 
- | [#0370-#037D] 
- | [#037F-#1FFF] 
- | [#200C-#200D] 
- | [#2070-#218F] 
- | [#2C00-#2FEF] 
- | [#3001-#D7FF] 
- | [#F900-#FDCF] 
- | [#FDF0-#FFFD] 
- | [#10000-#EFFFF] 
-[164s] PN_CHARS_U  ::=  PN_CHARS_BASE 
- | '_' 
-[166s] PN_CHARS ::= PN_CHARS_U 
- | "-" 
- | [0-9] 
- | #00B7 
- | [#0300-#036F] 
- | [#203F-#2040] 
-[167s] PN_PREFIX ::= PN_CHARS_BASE ( ( PN_CHARS | "." )* PN_CHARS )? 
- 
-[168s] PN_LOCAL ::= ( PN_CHARS_U | ':' | [0-9] | PLX ) ( ( PN_CHARS | '.' | ':' | PLX )*  ( PN_CHARS | ':' | PLX ) ) ?
-
-[169s] PLX ::= PERCENT | PN_LOCAL_ESC
-
-[170s] PERCENT ::= '%' HEX HEX
-
-[171s] HEX ::= [0-9] | [A-F] | [a-f]
-
-[172s] PN_LOCAL_ESC ::= '\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )
+IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+PNAME_NS          ::= PN_PREFIX? ":" 
+PNAME_LN          ::= PNAME_NS PN_LOCAL 
+BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
+LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* 
+INTEGER           ::= [+-]? [0-9]+
+DECIMAL           ::= [+-]?  ( ([0-9])* '.' ([0-9])+  )
+DOUBLE            ::= [+-]? ( [0-9]+ '.' [0-9]* EXPONENT | '.' ([0-9])+ EXPONENT | ([0-9])+ EXPONENT )
+EXPONENT          ::= [eE] [+-]? [0-9]+ 
+STRING_LITERAL_QUOTE              ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"' 
+STRING_LITERAL_SINGLE_QUOTE       ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'" 
+STRING_LITERAL_LONG_SINGLE_QUOTE  ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''" 
+STRING_LITERAL_LONG_QUOTE         ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""' 
+UCHAR             ::= ( "\u" HEX HEX HEX HEX ) | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX ) 
+ECHAR             ::= "\" [tbnrf\"'] 
+NIL               ::= "(" WS* ")" 
+WS                ::= #x20 | #x9 | #xD | #xA
+ANON              ::= "[" WS* "]" 
+PN_CHARS_BASE     ::= [A-Z]
+                    | [a-z]
+                    | [#x00C0-#x00D6]
+                    | [#x00D8-#x00F6]
+                    | [#x00F8-#x02FF]
+                    | [#x0370-#x037D]
+                    | [#x037F-#x1FFF]
+                    | [#x200C-#x200D]
+                    | [#x2070-#x218F]
+                    | [#x2C00-#x2FEF]
+                    | [#x3001-#xD7FF]
+                    | [#xF900-#xFDCF]
+                    | [#xFDF0-#xFFFD]
+                    | [#x10000-#xEFFFF]
+PN_CHARS_U        ::=  PN_CHARS_BASE | '_'
+PN_CHARS          ::= PN_CHARS_U
+                    | "-"
+                    | [0-9]
+                    | #x00B7
+                    | [#x0300-#x036F]
+                    | [#x203F-#x2040]
+PN_PREFIX         ::= PN_CHARS_BASE ( ( PN_CHARS | "." )* PN_CHARS )? 
+PN_LOCAL          ::= ( PN_CHARS_U | ':' | [0-9] | PLX ) ( ( PN_CHARS | '.' | ':' | PLX )*  ( PN_CHARS | ':' | PLX ) ) ?
+PLX               ::= PERCENT | PN_LOCAL_ESC
+PERCENT           ::= '%' HEX HEX
+HEX               ::= [0-9] | [A-F] | [a-f]
+PN_LOCAL_ESC      ::= '\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )

--- a/spec/turtle.bnf
+++ b/spec/turtle.bnf
@@ -1,28 +1,28 @@
-turtleDoc             ::= statement* 
-statement             ::= directive | triples "." 
+turtleDoc             ::= statement*
+statement             ::= directive | triples "."
 directive             ::= prefixID | base | sparqlPrefix | sparqlBase
 prefixID              ::= '@prefix' PNAME_NS IRIREF "."
 base                  ::= '@base' IRIREF "."
 sparqlPrefix          ::=	"PREFIX" PNAME_NS IRIREF
 sparqlBase            ::=	"BASE" IRIREF
-triples               ::= subject predicateObjectList | blankNodePropertyList predicateObjectList? 
+triples               ::= subject predicateObjectList | blankNodePropertyList predicateObjectList?
 predicateObjectList   ::= verb objectList (';' (verb objectList)? )*
-objectList            ::= object annotation? ( ',' object annotation? )* 
-verb                  ::= predicate | "a" 
+objectList            ::= object annotation? ( ',' object annotation? )*
+verb                  ::= predicate | "a"
 subject               ::= iri | BlankNode | collection | quotedTriple
 predicate             ::= iri
-object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | quotedTriple 
-literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral 
-blankNodePropertyList ::= "[" predicateObjectList "]" 
-collection            ::= "(" object* ")" 
-NumericLiteral        ::= INTEGER | DECIMAL | DOUBLE 
-RDFLiteral            ::= String ( LANGTAG | ( "^^" iri ) )? 
-BooleanLiteral        ::= "true" | "false" 
+object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | quotedTriple
+literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral
+blankNodePropertyList ::= "[" predicateObjectList "]"
+collection            ::= "(" object* ")"
+NumericLiteral        ::= INTEGER | DECIMAL | DOUBLE
+RDFLiteral            ::= String ( LANGTAG | ( "^^" iri ) )?
+BooleanLiteral        ::= "true" | "false"
 String                ::= STRING_LITERAL_QUOTE | STRING_LITERAL_SINGLE_QUOTE
-                        | STRING_LITERAL_LONG_SINGLE_QUOTE | STRING_LITERAL_LONG_QUOTE 
-iri                   ::= IRIREF | PrefixedName 
-PrefixedName          ::= PNAME_LN | PNAME_NS 
-BlankNode             ::= BLANK_NODE_LABEL | ANON 
+                        | STRING_LITERAL_LONG_SINGLE_QUOTE | STRING_LITERAL_LONG_QUOTE
+iri                   ::= IRIREF | PrefixedName
+PrefixedName          ::= PNAME_LN | PNAME_NS
+BlankNode             ::= BLANK_NODE_LABEL | ANON
 quotedTriple          ::= '<<' qtSubject predicate qtObject '>>'
 qtSubject             ::=	iri | BlankNode | quotedTriple
 qtObject              ::=	iri | BlankNode | literal | quotedTriple
@@ -31,24 +31,24 @@ annotation            ::= '{|' predicateObjectList '|}'
 @terminals
 
 IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
-PNAME_NS          ::= PN_PREFIX? ":" 
-PNAME_LN          ::= PNAME_NS PN_LOCAL 
+PNAME_NS          ::= PN_PREFIX? ":"
+PNAME_LN          ::= PNAME_NS PN_LOCAL
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
-LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )* 
+LANGTAG           ::= "@" [a-zA-Z]+ ( "-" [a-zA-Z0-9]+ )*
 INTEGER           ::= [+-]? [0-9]+
 DECIMAL           ::= [+-]?  ( ([0-9])* '.' ([0-9])+  )
 DOUBLE            ::= [+-]? ( [0-9]+ '.' [0-9]* EXPONENT | '.' ([0-9])+ EXPONENT | ([0-9])+ EXPONENT )
-EXPONENT          ::= [eE] [+-]? [0-9]+ 
-STRING_LITERAL_QUOTE              ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"' 
-STRING_LITERAL_SINGLE_QUOTE       ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'" 
-STRING_LITERAL_LONG_SINGLE_QUOTE  ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''" 
-STRING_LITERAL_LONG_QUOTE         ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""' 
-UCHAR             ::= ( "\u" HEX HEX HEX HEX ) | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX ) 
-ECHAR             ::= "\" [tbnrf\"'] 
-NIL               ::= "(" WS* ")" 
+EXPONENT          ::= [eE] [+-]? [0-9]+
+STRING_LITERAL_QUOTE              ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
+STRING_LITERAL_SINGLE_QUOTE       ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'"
+STRING_LITERAL_LONG_SINGLE_QUOTE  ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''"
+STRING_LITERAL_LONG_QUOTE         ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""'
+UCHAR             ::= ( "\u" HEX HEX HEX HEX ) | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )
+ECHAR             ::= ("\" [tbnrf\"'])
+NIL               ::= "(" WS* ")"
 WS                ::= #x20 | #x9 | #xD | #xA
-ANON              ::= "[" WS* "]" 
-PN_CHARS_BASE     ::= [A-Z]
+ANON              ::= "[" WS* "]"
+PN_CHARS_BASE     ::= ([A-Z]
                     | [a-z]
                     | [#x00C0-#x00D6]
                     | [#x00D8-#x00F6]
@@ -61,17 +61,17 @@ PN_CHARS_BASE     ::= [A-Z]
                     | [#x3001-#xD7FF]
                     | [#xF900-#xFDCF]
                     | [#xFDF0-#xFFFD]
-                    | [#x10000-#xEFFFF]
+                    | [#x10000-#xEFFFF])
 PN_CHARS_U        ::=  PN_CHARS_BASE | '_'
-PN_CHARS          ::= PN_CHARS_U
+PN_CHARS          ::= (PN_CHARS_U
                     | "-"
                     | [0-9]
                     | #x00B7
                     | [#x0300-#x036F]
-                    | [#x203F-#x2040]
-PN_PREFIX         ::= PN_CHARS_BASE ( ( PN_CHARS | "." )* PN_CHARS )? 
+                    | [#x203F-#x2040])
+PN_PREFIX         ::= PN_CHARS_BASE ( ( PN_CHARS | "." )* PN_CHARS )?
 PN_LOCAL          ::= ( PN_CHARS_U | ':' | [0-9] | PLX ) ( ( PN_CHARS | '.' | ':' | PLX )*  ( PN_CHARS | ':' | PLX ) ) ?
 PLX               ::= PERCENT | PN_LOCAL_ESC
 PERCENT           ::= '%' HEX HEX
-HEX               ::= [0-9] | [A-F] | [a-f]
+HEX               ::= ([0-9] | [A-F] | [a-f])
 PN_LOCAL_ESC      ::= '\' ( '_' | '~' | '.' | '-' | '!' | '$' | '&' | "'" | '(' | ')' | '*' | '+' | ',' | ';' | '=' | '/' | '?' | '#' | '@' | '%' )

--- a/spec/turtle.bnf
+++ b/spec/turtle.bnf
@@ -30,7 +30,7 @@ annotation            ::= '{|' predicateObjectList '|}'
 
 @terminals
 
-IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+IRIREF            ::=  '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>' /* #x00=NULL #01-#x1F=control codes #x20=space */
 PNAME_NS          ::= PN_PREFIX? ":"
 PNAME_LN          ::= PNAME_NS PN_LOCAL
 BLANK_NODE_LABEL  ::= '_:' ( PN_CHARS_U | [0-9] ) ((PN_CHARS|'.')* PN_CHARS)?
@@ -39,14 +39,14 @@ INTEGER           ::= [+-]? [0-9]+
 DECIMAL           ::= [+-]?  ( ([0-9])* '.' ([0-9])+  )
 DOUBLE            ::= [+-]? ( [0-9]+ '.' [0-9]* EXPONENT | '.' ([0-9])+ EXPONENT | ([0-9])+ EXPONENT )
 EXPONENT          ::= [eE] [+-]? [0-9]+
-STRING_LITERAL_QUOTE              ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"'
-STRING_LITERAL_SINGLE_QUOTE       ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'"
+STRING_LITERAL_QUOTE              ::= '"' ( [^#x22#x5C#xA#xD] | ECHAR | UCHAR )* '"' /* #x22=" #x5C=\ #xA=new line #xD=carriage return */
+STRING_LITERAL_SINGLE_QUOTE       ::= "'" ( [^#x27#x5C#xA#xD] | ECHAR | UCHAR )* "'" /* #x27=' #x5C=\ #xA=new line #xD=carriage return */
 STRING_LITERAL_LONG_SINGLE_QUOTE  ::= "'''" ( ( "'" | "''" )? ( [^'\] | ECHAR | UCHAR ) )* "'''"
 STRING_LITERAL_LONG_QUOTE         ::= '"""' ( ( '"' | '""' )? ( [^"\] | ECHAR | UCHAR ) )* '"""'
 UCHAR             ::= ( "\u" HEX HEX HEX HEX ) | ( "\U" HEX HEX HEX HEX HEX HEX HEX HEX )
 ECHAR             ::= ("\" [tbnrf\"'])
 NIL               ::= "(" WS* ")"
-WS                ::= #x20 | #x9 | #xD | #xA
+WS                ::= #x20 | #x9 | #xD | #xA /* #x20=space #x9=character tabulation #xD=carriage return #xA=new line */
 ANON              ::= "[" WS* "]"
 PN_CHARS_BASE     ::= ([A-Z]
                     | [a-z]


### PR DESCRIPTION
Adds the [CG Report](https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#turtle-star) changes for Turtle. Annotation syntax is tentative depending on potential changes to semantics, but matches the SPARQL annotation form.

* [x] EBNF Grammar
* [x] Spec Text (based on [CG Report](https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#turtle-star)
* [x] Parser states
* [x] Examples
* [x] Changes

Fixes #26.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/27.html" title="Last updated on Jun 7, 2023, 6:15 PM UTC (ba371d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/27/f6edce6...ba371d8.html" title="Last updated on Jun 7, 2023, 6:15 PM UTC (ba371d8)">Diff</a>