### PR TITLE
Change SPARQL Reference from obsolete GraphTerm …

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -936,8 +936,8 @@
   </p>
 
   <ol>
-    <li><a data-cite="SPARQL12-QUERY#rGraphTerm">SPARQL permits RDF Literals</a>
-      as the subject of RDF triples.</li>
+    <li>SPARQL permits <a data-cite="RDF12-CONCEPTS#dfn-literal">RDF Literals</a>
+      as the subject of <a data-cite="SPARQL12-QUERY#sparqlTriplePatterns">Triple Patterns</a>.</li>
     <li>SPARQL permits variables (<code>?</code><em>name</em> or <code>$</code><em>name</em>)
       in any part of the triple of the form.</li>
     <li>Turtle allows <a href="#grammar-production-directive">prefix and base declarations</a>


### PR DESCRIPTION
… to the section on Triple Patterns.

Fixes #28.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/30.html" title="Last updated on Jun 9, 2023, 11:55 PM UTC (606b41a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/30/2faa62c...606b41a.html" title="Last updated on Jun 9, 2023, 11:55 PM UTC (606b41a)">Diff</a>