### PR TITLE
add references to XMLSCHEMA11-2 in the subsection about booleans

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -581,7 +581,7 @@
       <h3>Booleans</h3>
       <p>Boolean values may be written as either '<code>true</code>'
         or '<code>false</code>' (case-sensitive)
-        and represent RDF literals with the datatype <a data-cite="xmlschema11-2#boolean">xsd:boolean</a>.</p>
+        and represent RDF literals with the datatype <a data-cite="xmlschema11-2#boolean">xsd:boolean</a> [[XMLSCHEMA11-2]].</p>
       <pre id="ex-boolean"
            class="example turtle" data-transform="updateExample"
            title="Boolean Literals">


### PR DESCRIPTION
solves https://github.com/w3c/rdf-turtle/issues/42


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/43.html" title="Last updated on Sep 21, 2023, 12:44 PM UTC (1152f54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/43/3aad884...1152f54.html" title="Last updated on Sep 21, 2023, 12:44 PM UTC (1152f54)">Diff</a>