### PR TITLE
Fix typo in spec

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -239,7 +239,7 @@
 
     <pre id="ex-predicateObjectList-expanded"
          class="example turtle" data-transform="updateExample"
-         title="Predicate List expanded to Simiple Triples">
+         title="Predicate List expanded to Simple Triples">
       <!--
       <http://example.org/#spiderman> <http://www.perceive.net/schemas/relationship/enemyOf> <http://example.org/#green-goblin> .
       <http://example.org/#spiderman> <http://xmlns.com/foaf/0.1/name> "Spiderman" .


### PR DESCRIPTION
Hi folks, I was just reading the new specs and noticed a typo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/hyfen/rdf-turtle/pull/44.html" title="Last updated on Sep 25, 2023, 2:56 AM UTC (fc2aea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/44/ba26beb...hyfen:fc2aea2.html" title="Last updated on Sep 25, 2023, 2:56 AM UTC (fc2aea2)">Diff</a>