### PR TITLE
Updates test suite location

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -11,7 +11,7 @@
       localBiblio:          localBibliography,
       specStatus:           "ED",
       edDraftURI:           "https://w3c.github.io/rdf-turtle/spec/",
-      testSuiteURI:         "https://w3c.github.io/rdf-tests/turtle/",
+      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle/",
       shortName:            "rdf12-turtle",
       subtitle   :          "Terse RDF Triple Language",
       copyrightStart:       "2008",


### PR DESCRIPTION
New locateion is https://w3c.github.io/rdf-tests/rdf/rdf12/rdf-turtle, which also includes RDF 1.1 tests.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/50.html" title="Last updated on Nov 3, 2023, 8:10 PM UTC (9efdcd4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/50/6559dc9...9efdcd4.html" title="Last updated on Nov 3, 2023, 8:10 PM UTC (9efdcd4)">Diff</a>