### PR TITLE
Grammar updates for triple terms and occurrences.

### DIFF
--- a/spec/turtle-bnf.html
+++ b/spec/turtle-bnf.html
@@ -1,4 +1,4 @@
-<!-- Generated with ebnf version 2.3.4. See https://github.com/dryruby/ebnf. -->
+<!-- Generated with ebnf version 2.5.0. See https://github.com/dryruby/ebnf. -->
 <table class="grammar">
   <tbody id="grammar-productions" class="ebnf">
     <tr id="grammar-production-turtleDoc">
@@ -71,7 +71,7 @@
       <td>[12]</td>
       <td><code>subject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleOccurrence">tripleOccurrence</a></td>
     </tr>
     <tr id="grammar-production-predicate">
       <td>[13]</td>
@@ -83,7 +83,7 @@
       <td>[14]</td>
       <td><code>object</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-collection">collection</a> <code class="grammar-alt">|</code> <a href="#grammar-production-blankNodePropertyList">blankNodePropertyList</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleOccurrence">tripleOccurrence</a></td>
     </tr>
     <tr id="grammar-production-literal">
       <td>[15]</td>
@@ -145,29 +145,35 @@
       <td>::=</td>
       <td><a href="#grammar-production-BLANK_NODE_LABEL">BLANK_NODE_LABEL</a> <code class="grammar-alt">|</code> <a href="#grammar-production-ANON">ANON</a></td>
     </tr>
-    <tr id="grammar-production-quotedTriple">
+    <tr id="grammar-production-tripleTerm">
       <td>[25]</td>
-      <td><code>quotedTriple</code></td>
+      <td><code>tripleTerm</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">&lt;&lt;</code>' <a href="#grammar-production-qtSubject">qtSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-qtObject">qtObject</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
+      <td>'<code class="grammar-literal">&lt;&lt;(</code>' <a href="#grammar-production-ttSubject">ttSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-ttObject">ttObject</a> '<code class="grammar-literal">)&gt;&gt;</code>'</td>
     </tr>
-    <tr id="grammar-production-qtSubject">
+    <tr id="grammar-production-tripleOccurrence">
       <td>[26]</td>
-      <td><code>qtSubject</code></td>
+      <td><code>tripleOccurrence</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td>'<code class="grammar-literal">&lt;&lt;</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">|</code>' <code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-ttSubject">ttSubject</a> <a href="#grammar-production-predicate">predicate</a> <a href="#grammar-production-ttObject">ttObject</a> '<code class="grammar-literal">&gt;&gt;</code>'</td>
     </tr>
-    <tr id="grammar-production-qtObject">
+    <tr id="grammar-production-ttSubject">
       <td>[27]</td>
-      <td><code>qtObject</code></td>
+      <td><code>ttSubject</code></td>
       <td>::=</td>
-      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-quotedTriple">quotedTriple</a></td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleOccurrence">tripleOccurrence</a></td>
+    </tr>
+    <tr id="grammar-production-ttObject">
+      <td>[28]</td>
+      <td><code>ttObject</code></td>
+      <td>::=</td>
+      <td><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a> <code class="grammar-alt">|</code> <a href="#grammar-production-literal">literal</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleTerm">tripleTerm</a> <code class="grammar-alt">|</code> <a href="#grammar-production-tripleOccurrence">tripleOccurrence</a></td>
     </tr>
     <tr id="grammar-production-annotation">
-      <td>[28]</td>
+      <td>[29]</td>
       <td><code>annotation</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">{|</code>' <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
+      <td>'<code class="grammar-literal">{|</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-iri">iri</a> <code class="grammar-alt">|</code> <a href="#grammar-production-BlankNode">BlankNode</a><code class="grammar-paren">)</code> '<code class="grammar-literal">|</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <a href="#grammar-production-predicateObjectList">predicateObjectList</a> '<code class="grammar-literal">|}</code>'</td>
     </tr>
     <tr id="grammar-declaration-terminals">
       <td colspan="4">
@@ -175,62 +181,62 @@
       </td>
     </tr>
     <tr id="grammar-production-IRIREF">
-      <td>[30]</td>
+      <td>[31]</td>
       <td><code>IRIREF</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&lt;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="null">#x00</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code><code class="grammar-literal">&lt;&gt;&quot;{}|^`\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&gt;</code>'
         <br/><span class="grammar_comment">/* #x00=NULL #x01-#x1F=control codes #x20=space */</span></td>
     </tr>
     <tr id="grammar-production-PNAME_NS">
-      <td>[31]</td>
+      <td>[32]</td>
       <td><code>PNAME_NS</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_PREFIX">PN_PREFIX</a><code class="grammar-opt">?</code> '<code class="grammar-literal">:</code>'</td>
     </tr>
     <tr id="grammar-production-PNAME_LN">
-      <td>[32]</td>
+      <td>[33]</td>
       <td><code>PNAME_LN</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PNAME_NS">PNAME_NS</a> <a href="#grammar-production-PN_LOCAL">PN_LOCAL</a></td>
     </tr>
     <tr id="grammar-production-BLANK_NODE_LABEL">
-      <td>[33]</td>
+      <td>[34]</td>
       <td><code>BLANK_NODE_LABEL</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">_:</code>' <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-LANG_DIR">
-      <td>[34]</td>
+      <td>[35]</td>
       <td><code>LANG_DIR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">@</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">-</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">--</code>' <code class="grammar-brac">[</code><code class="grammar-literal">a-zA-Z</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-INTEGER">
-      <td>[35]</td>
+      <td>[36]</td>
       <td><code>INTEGER</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-DECIMAL">
-      <td>[36]</td>
+      <td>[37]</td>
       <td><code>DECIMAL</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> '<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-DOUBLE">
-      <td>[37]</td>
+      <td>[38]</td>
       <td><code>DOUBLE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> '<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-star">*</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">.</code>' <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code> <a href="#grammar-production-EXPONENT">EXPONENT</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-EXPONENT">
-      <td>[38]</td>
+      <td>[39]</td>
       <td><code>EXPONENT</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">eE</code><code class="grammar-brac">]</code> <code class="grammar-brac">[</code><code class="grammar-literal">+-</code><code class="grammar-brac">]</code><code class="grammar-opt">?</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code><code class="grammar-plus">+</code></td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_QUOTE">
-      <td>[39]</td>
+      <td>[40]</td>
       <td><code>STRING_LITERAL_QUOTE</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="dquote">#x22</abbr></code><code class="grammar-char-escape"><abbr title="backslash">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;</code>'
@@ -238,7 +244,7 @@
       </td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_SINGLE_QUOTE">
-      <td>[40]</td>
+      <td>[41]</td>
       <td><code>STRING_LITERAL_SINGLE_QUOTE</code></td>
       <td>::=</td>
       <td>"<code class="grammar-literal">&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^</code><code class="grammar-char-escape"><abbr title="apos">#x27</abbr></code><code class="grammar-char-escape"><abbr title="backslash">#x5C</abbr></code><code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code><code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;</code>"
@@ -246,37 +252,37 @@
       </td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_SINGLE_QUOTE">
-      <td>[41]</td>
+      <td>[42]</td>
       <td><code>STRING_LITERAL_LONG_SINGLE_QUOTE</code></td>
       <td>::=</td>
       <td>"<code class="grammar-literal">&apos;&apos;&apos;</code>" <code class="grammar-paren">(</code><code class="grammar-paren">(</code>"<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;&apos;</code>"<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&apos;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> "<code class="grammar-literal">&apos;&apos;&apos;</code>"</td>
     </tr>
     <tr id="grammar-production-STRING_LITERAL_LONG_QUOTE">
-      <td>[42]</td>
+      <td>[43]</td>
       <td><code>STRING_LITERAL_LONG_QUOTE</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">&quot;&quot;&quot;</code>' <code class="grammar-paren">(</code><code class="grammar-paren">(</code>'<code class="grammar-literal">&quot;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&quot;&quot;</code>'<code class="grammar-paren">)</code><code class="grammar-opt">?</code> <code class="grammar-paren">(</code><code class="grammar-brac">[</code><code class="grammar-literal">^&quot;\</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-ECHAR">ECHAR</a> <code class="grammar-alt">|</code> <a href="#grammar-production-UCHAR">UCHAR</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-star">*</code> '<code class="grammar-literal">&quot;&quot;&quot;</code>'</td>
     </tr>
     <tr id="grammar-production-UCHAR">
-      <td>[43]</td>
+      <td>[44]</td>
       <td><code>UCHAR</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code>'<code class="grammar-literal">\u</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code> <code class="grammar-alt">|</code> <code class="grammar-paren">(</code>'<code class="grammar-literal">\U</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a><code class="grammar-paren">)</code></td>
     </tr>
     <tr id="grammar-production-ECHAR">
-      <td>[44]</td>
+      <td>[45]</td>
       <td><code>ECHAR</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">\</code>' <code class="grammar-brac">[</code><code class="grammar-literal">tbnrf\&quot;&apos;</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-NIL">
-      <td>[45]</td>
+      <td>[46]</td>
       <td><code>NIL</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">(</code>' <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> '<code class="grammar-literal">)</code>'</td>
     </tr>
     <tr id="grammar-production-WS">
-      <td>[46]</td>
+      <td>[47]</td>
       <td><code>WS</code></td>
       <td>::=</td>
       <td><code class="grammar-char-escape"><abbr title="space">#x20</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="horizontal tab">#x09</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="carriage return">#x0D</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="new line">#x0A</abbr></code>
@@ -284,13 +290,13 @@
       </td>
     </tr>
     <tr id="grammar-production-ANON">
-      <td>[47]</td>
+      <td>[48]</td>
       <td><code>ANON</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">[</code>' <a href="#grammar-production-WS">WS</a><code class="grammar-star">*</code> '<code class="grammar-literal">]</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS_BASE">
-      <td>[48]</td>
+      <td>[49]</td>
       <td><code>PN_CHARS_BASE</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">A-Z</code><code class="grammar-brac">]</code></td>
@@ -361,52 +367,52 @@
       <td><code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+10000">#x00010000</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+EFFFF">#x000EFFFF</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_CHARS_U">
-      <td>[49]</td>
+      <td>[50]</td>
       <td><code>PN_CHARS_U</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">_</code>'</td>
     </tr>
     <tr id="grammar-production-PN_CHARS">
-      <td>[50]</td>
+      <td>[51]</td>
       <td><code>PN_CHARS</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-char-escape"><abbr title="unicode U+00B7">#xB7</abbr></code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+0300">#x0300</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+036F">#x036F</abbr></code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-char-escape"><abbr title="unicode U+203F">#x203F</abbr></code><code class="grammar-literal">-</code><code class="grammar-char-escape"><abbr title="unicode U+2040">#x2040</abbr></code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_PREFIX">
-      <td>[51]</td>
+      <td>[52]</td>
       <td><code>PN_PREFIX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PN_CHARS_BASE">PN_CHARS_BASE</a> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>'<code class="grammar-paren">)</code><code class="grammar-star">*</code> <a href="#grammar-production-PN_CHARS">PN_CHARS</a><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL">
-      <td>[52]</td>
+      <td>[53]</td>
       <td><code>PN_LOCAL</code></td>
       <td>::=</td>
       <td><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS_U">PN_CHARS_U</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code> <code class="grammar-paren">(</code><code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-star">*</code> <code class="grammar-paren">(</code><a href="#grammar-production-PN_CHARS">PN_CHARS</a> <code class="grammar-alt">|</code> '<code class="grammar-literal">:</code>' <code class="grammar-alt">|</code> <a href="#grammar-production-PLX">PLX</a><code class="grammar-paren">)</code><code class="grammar-paren">)</code><code class="grammar-opt">?</code></td>
     </tr>
     <tr id="grammar-production-PLX">
-      <td>[53]</td>
+      <td>[54]</td>
       <td><code>PLX</code></td>
       <td>::=</td>
       <td><a href="#grammar-production-PERCENT">PERCENT</a> <code class="grammar-alt">|</code> <a href="#grammar-production-PN_LOCAL_ESC">PN_LOCAL_ESC</a></td>
     </tr>
     <tr id="grammar-production-PERCENT">
-      <td>[54]</td>
+      <td>[55]</td>
       <td><code>PERCENT</code></td>
       <td>::=</td>
       <td>'<code class="grammar-literal">%</code>' <a href="#grammar-production-HEX">HEX</a> <a href="#grammar-production-HEX">HEX</a></td>
     </tr>
     <tr id="grammar-production-HEX">
-      <td>[55]</td>
+      <td>[56]</td>
       <td><code>HEX</code></td>
       <td>::=</td>
       <td><code class="grammar-brac">[</code><code class="grammar-literal">0-9</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">A-F</code><code class="grammar-brac">]</code> <code class="grammar-alt">|</code> <code class="grammar-brac">[</code><code class="grammar-literal">a-f</code><code class="grammar-brac">]</code></td>
     </tr>
     <tr id="grammar-production-PN_LOCAL_ESC">
-      <td>[56]</td>
+      <td>[57]</td>
       <td><code>PN_LOCAL_ESC</code></td>
       <td>::=</td>
-      <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">!</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&apos;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>
+      <td>'<code class="grammar-literal">\</code>' <code class="grammar-paren">(</code>'<code class="grammar-literal">_</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">~</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">.</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">-</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">!</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">$</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">&amp;</code>' <code class="grammar-alt">|</code> "<code class="grammar-literal">&apos;</code>" <code class="grammar-alt">|</code> '<code class="grammar-literal">(</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">)</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">*</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">+</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">,</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">;</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">=</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">/</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">?</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">#</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">@</code>' <code class="grammar-alt">|</code> '<code class="grammar-literal">%</code>'<code class="grammar-paren">)</code></td>
     </tr>
   </tbody>
 </table>

--- a/spec/turtle.bnf
+++ b/spec/turtle.bnf
@@ -9,9 +9,9 @@ triples               ::= subject predicateObjectList | blankNodePropertyList pr
 predicateObjectList   ::= verb objectList (';' (verb objectList)? )*
 objectList            ::= object annotation? ( ',' object annotation? )*
 verb                  ::= predicate | 'a'
-subject               ::= iri | BlankNode | collection | quotedTriple
+subject               ::= iri | BlankNode | collection | tripleTerm | tripleOccurrence
 predicate             ::= iri
-object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | quotedTriple
+object                ::= iri | BlankNode | collection | blankNodePropertyList | literal | tripleTerm | tripleOccurrence
 literal               ::= RDFLiteral | NumericLiteral | BooleanLiteral
 blankNodePropertyList ::= '[' predicateObjectList ']'
 collection            ::= '(' object* ')'
@@ -23,10 +23,11 @@ String                ::= STRING_LITERAL_QUOTE | STRING_LITERAL_SINGLE_QUOTE
 iri                   ::= IRIREF | PrefixedName
 PrefixedName          ::= PNAME_LN | PNAME_NS
 BlankNode             ::= BLANK_NODE_LABEL | ANON
-quotedTriple          ::= '<<' qtSubject predicate qtObject '>>'
-qtSubject             ::=	iri | BlankNode | quotedTriple
-qtObject              ::=	iri | BlankNode | literal | quotedTriple
-annotation            ::= '{|' predicateObjectList '|}'
+tripleTerm            ::= '<<(' ttSubject predicate ttObject ')>>'
+tripleOccurrence      ::= '<<' ( '|' (iri | BlankNode) '|' )? ttSubject predicate ttObject '>>'
+ttSubject             ::=	iri | BlankNode | tripleTerm | tripleOccurrence
+ttObject              ::=	iri | BlankNode | literal | tripleTerm | tripleOccurrence
+annotation            ::= '{|' ( (iri | BlankNode) '|' )? predicateObjectList '|}'
 
 @terminals
 


### PR DESCRIPTION
* Changes `quotedTriple` (and related) to `tripleOccurrence`.
* Adds `tripleTerm`.
* Changes `annotation` to allow an identifier. (Note, this change makes the grammar no longer context free).
