### PR TITLE
fix missing protocols in e-mail IRIs

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -725,7 +725,7 @@
               foaf:name "Bob" ;
               foaf:knows [
                   foaf:name "Eve" ] ;
-              foaf:mbox <bob@example.com> ] .
+              foaf:mbox <mailto:bob@example.com> ] .
           -->
         </pre>
       </td>
@@ -737,7 +737,7 @@
           _:b <http://xmlns.com/foaf/0.1/name> "Bob" .
           _:b <http://xmlns.com/foaf/0.1/knows> _:c .
           _:c <http://xmlns.com/foaf/0.1/name> "Eve" .
-          _:b <http://xmlns.com/foaf/0.1/mbox> <bob@example.com> .
+          _:b <http://xmlns.com/foaf/0.1/mbox> <mailto:bob@example.com> .
           -->
         </pre>
       </td>


### PR DESCRIPTION
This follows a bit of search and a stackoverflow question&answer here: https://stackoverflow.com/questions/35501103/are-email-addresses-without-mailto-allowed-as-iris

Even if the example is valid without the protocol prefixes, I believe the reason why it is indeed valid should be explained or referred to, in order to prevent confusion. If that's the case please let me know.

Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 4, 2024, 8:06 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/rdf-turtle%2353.)._
</details>
