### PR TITLE
Fix some prefixes in Turtle examples to create better IRIs.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -598,7 +598,7 @@
            class="example turtle" data-transform="updateExample"
            title="Number Literals">
         <!--
-        PREFIX : <http://example.org/elements>
+        PREFIX : <http://example.org/elements/>
         <http://en.wikipedia.org/wiki/Helium>
             :atomicNumber 2 ;               # xsd:integer
             :atomicMass 4.002602 ;          # xsd:decimal
@@ -616,7 +616,7 @@
            class="example turtle" data-transform="updateExample"
            title="Boolean Literals">
         <!--
-        PREFIX : <http://example.org/stats>
+        PREFIX : <http://example.org/stats/>
         <http://somecountry.example/census2007>
             :isLandlocked false .           # xsd:boolean
         -->
@@ -769,7 +769,7 @@
          class="example turtle" data-transform="updateExample"
          title="Collections in Turtle">
       <!--
-      PREFIX : <http://example.org/foo>
+      PREFIX : <http://example.org/foo/>
       # the object of this triple is the RDF collection blank node
       :subject :predicate ( :a :b :c ) .
 


### PR DESCRIPTION
Fixes #52.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/54.html" title="Last updated on Feb 5, 2024, 5:41 PM UTC (39d013a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/54/4e5b70c...39d013a.html" title="Last updated on Feb 5, 2024, 5:41 PM UTC (39d013a)">Diff</a>