### PR TITLE
proceed -> precede

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -918,11 +918,11 @@
         one or more <a>reifiers</a> as either <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>
         or <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>,
         each preceded by a tilde (<a href="#cp-tilde"><code title="tilde">~</code></a>),
-        which proceeds the annotation block.
+        which precedes the annotation block.
         If not followed by an annotation block, a <a>reifier</a>
         is treated like a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
         without annotations.
-        If an annotation block is not proceeded by a <a>reifier</a>,
+        If an annotation block is not preceded by a <a>reifier</a>,
         an RDF blank node is allocated to serve as the <a>reifier</a> of the
         <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
       </p>


### PR DESCRIPTION
The use of "proceed" was confusing to me here (although technically it may be correct). 
I think "precede" is much more common in this case, and it seems to be used with the same meaning in other cases of the spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/william-vw/rdf-turtle/pull/64.html" title="Last updated on Aug 15, 2024, 1:57 PM UTC (5398ea8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/64/23809b8...william-vw:5398ea8.html" title="Last updated on Aug 15, 2024, 1:57 PM UTC (5398ea8)">Diff</a>