### PR TITLE
Adding a flattened version of the syntactic sugar & note on the difference between the regular and syntactic sugar syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -891,7 +891,7 @@
 
     <!-- sorry, I'm unsure how to refer to a specific example with a hyperlink -->
     For instance, the syntactic sugar of the above example is equivalent to:
-    <pre id="ex-reified-triple-with-reifier"
+    <pre id="ex-reified-triple-with-reifier-expanded"
          class="example turtle" data-transform="updateExample"
          title="Reified Triple expanded to Triple Term">
       <!--

--- a/spec/index.html
+++ b/spec/index.html
@@ -893,7 +893,7 @@
     For instance, the syntactic sugar of the above example is equivalent to:
     <pre id="ex-reified-triple-with-reifier"
          class="example turtle" data-transform="updateExample"
-         title="Expanded N-TRIPLES version of Reified Triple">
+         title="Reified Triple expanded to Triple Term">
       <!--
       PREFIX :    <http://www.example.org/>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -918,11 +918,11 @@
         one or more <a>reifiers</a> as either <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>
         or <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>,
         each preceded by a tilde (<a href="#cp-tilde"><code title="tilde">~</code></a>),
-        which proceeds the annotation block.
+        which precedes the annotation block.
         If not followed by an annotation block, a <a>reifier</a>
         is treated like a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
         without annotations.
-        If an annotation block is not proceeded by a <a>reifier</a>,
+        If an annotation block is not preceded by a <a>reifier</a>,
         an RDF blank node is allocated to serve as the <a>reifier</a> of the
         <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
       </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -876,6 +876,8 @@
       -->
     </pre>
 
+    <!-- possibly add the equivalent N-TRIPLE for the above here as well -->
+
     <pre id="ex-reified-triple-with-reifier"
          class="example turtle" data-transform="updateExample"
          title="Reified Triple with explicit reifier">
@@ -886,6 +888,23 @@
       << :employee38 :jobTitle "Assistant Designer" ~ _:id >> :accordingTo :employee22 .
       -->
     </pre>
+
+    <!-- sorry, I'm unsure how to refer to a specific example with a hyperlink -->
+    For instance, the syntactic sugar of the above example is equivalent to:
+    <pre id="ex-reified-triple-with-reifier"
+         class="example turtle" data-transform="updateExample"
+         title="Expanded N-TRIPLES version of Reified Triple">
+      <!--
+      PREFIX :    <http://www.example.org/>
+
+      :employee38 :familyName "Smith" .
+      _:id rdf:reifies <<( :employee38 :jobTitle "Assistant Designer" )>> .
+      _:id :accordingTo :employee22 .
+      -->
+    </pre>
+
+    <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>, 
+      i.e., `<< [...] >>` vs. the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>, i.e., `<<( [...] )>>`.</p>
 
     <p>After declaring a prefix so that IRIs can be abbreviated,
       the first triple in this example asserts that `employee38` has a `familyName` of "Smith".

--- a/spec/index.html
+++ b/spec/index.html
@@ -903,8 +903,8 @@
       -->
     </pre>
 
-    <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>, 
-      i.e., `<< [...] >>` vs. the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>, i.e., `<<( [...] )>>`.</p>
+    <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+      (i.e., `<< [...] >>`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> (i.e., `<<( [...] )>>`).</p>
 
     <p>After declaring a prefix so that IRIs can be abbreviated,
       the first triple in this example asserts that `employee38` has a `familyName` of "Smith".


### PR DESCRIPTION
(sorry if I messed up this pull request, only the latest commit is relevant)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/william-vw/rdf-turtle/pull/65.html" title="Last updated on Aug 16, 2024, 9:20 PM UTC (ebfb57e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/65/10ed728...william-vw:ebfb57e.html" title="Last updated on Aug 16, 2024, 9:20 PM UTC (ebfb57e)">Diff</a>