### PR TITLE
Adds a link to the text version of the BNF file.

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1453,6 +1453,7 @@
     </div>
 
     <div data-include="turtle-bnf.html"></div>
+    <p>A text version of this grammar is available <a href="turtle.bnf">here</a>.</p>
   </section>
 
   <section>


### PR DESCRIPTION
This makes it more convenient for people to access the EBNF without having to scrape the HTML.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/72.html" title="Last updated on Sep 18, 2024, 7:34 PM UTC (f1071bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/72/55a4f08...f1071bb.html" title="Last updated on Sep 18, 2024, 7:34 PM UTC (f1071bb)">Diff</a>