### PR TITLE
GH-81: Clarify scope of reifier of an annotation block

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -946,7 +946,7 @@
         If not followed by an annotation block, a <a>reifier</a>
         is treated like a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
         without annotations.
-        If an annotation block is not preceded by a <a>reifier</a>,
+        If an annotation block is not immediately preceded by a <a>reifier</a>,
         an RDF blank node is allocated to serve as the <a>reifier</a> of the
         <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
       </p>


### PR DESCRIPTION
This closes #81.

The OP suggested 
"If an annotation block is not directly preceded by"

This PR uses "immediately preceded by".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/82.html" title="Last updated on Jan 7, 2025, 9:30 PM UTC (e457eac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/82/ce11476...e457eac.html" title="Last updated on Jan 7, 2025, 9:30 PM UTC (e457eac)">Diff</a>