### PR TITLE
Clarify IRI reference resolution in Turtle (absolute vs. relative)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -421,11 +421,46 @@
       may contain <a>numeric escape sequences</a> (described below).
       For example, <code>&lt;http://example.org/#green-goblin&gt;</code>.
     </p>
-    <p id="relative-iri"><a data-cite="RDF12-CONCEPTS#dfn-relative-iri">Relative IRI references</a> like <code>&lt;#green-goblin&gt;</code>
+    <p id="relative-iri">
+      <a data-cite="RDF12-CONCEPTS#dfn-relative-iri">Relative IRI references</a> like <code>&lt;#green-goblin&gt;</code>
       are resolved relative to the current base IRI.
       A new base IRI can be defined using the <code>@base</code> or <a href="#grammar-production-sparqlBase"><code>BASE</code></a>
       directive. Specifics of this operation are defined in
-      <a href="#sec-iri-references" class="sectionRef"></a>.</p>
+      <a href="#iri-resolution" class="sectionRef">Reference Resolution</a>.
+    </p>
+
+    <section id="iri-resolution">
+      <h4>Reference Resolution</h4>
+      <p>
+        When parsing an IRI written in angle brackets (<code>IRIREF</code>), processors MUST
+        distinguish between:
+      </p>
+      <ul>
+        <li>
+          <strong>Absolute IRI references</strong> (i.e., with a scheme per [[RFC3986]]): the IRI MUST be used <em>verbatim</em>
+          to construct the RDF term. Processors MUST NOT apply reference resolution
+          (including the <em>remove_dot_segments</em> step from [[RFC3986]] §5.2) nor perform
+          any path normalization on such IRIs.
+        </li>
+        <li>
+          <strong>Relative IRI references</strong>: the reference MUST be resolved against the current
+          <a data-cite="RDF12-CONCEPTS#dfn-base-iri">base IRI</a> following [[RFC3986]] §5.1–§5.2. This resolution can
+          remove “<code>/./</code>” and “<code>/../</code>” path segments as part of the algorithm.
+        </li>
+      </ul>
+      <p>
+        This rule prevents the same lexical IRI from yielding different RDF terms depending on whether a
+        <code>BASE</code> directive is present. It aligns with
+        <a data-cite="RDF12-CONCEPTS#iri-equality">IRI equality</a> in RDF 1.2 Concepts, which uses simple string comparison and
+        forbids additional normalization before comparison.
+      </p>
+      <p class="note">
+        Data publishers are encouraged to mint <a data-cite="RDF12-CONCEPTS#reference-iris">RDF Reference IRIs</a>,
+        i.e., IRIs suitable as global references that are unchanged by reference resolution and whose path
+        starts with “<code>/</code>” and does not contain “<code>.</code>” or “<code>..</code>” segments.
+        This improves interoperability across concrete syntaxes.
+      </p>
+    </section>
 
     <p id="iri-a">
       The token <a href="#cp-lowercase-a"><code>a</code></a> in the predicate position of a Turtle triple

--- a/spec/index.html
+++ b/spec/index.html
@@ -432,8 +432,8 @@
     <section id="iri-resolution">
       <h4>Reference Resolution</h4>
       <p>
-        When parsing an IRI written in angle brackets (<code>IRIREF</code>), processors MUST
-        distinguish between:
+        When parsing an IRI written in angle brackets (<code>&ld; &gt;</code>, <code>IRIREF</code>),
+        processors MUST distinguish between:
       </p>
       <ul>
         <li>


### PR DESCRIPTION
fixes #89

### Summary
This PR clarifies that Turtle processors **MUST** treat **absolute IRIs** (with a scheme) as **verbatim** and **MUST NOT** apply RFC 3986 §5 reference resolution or path normalization to them. Only **relative IRI references** are resolved against the current base IRI per RFC 3986 §5.1–§5.2.

### Rationale
Without this clarification, an absolute IRI containing dot-segments can be altered depending on whether a `BASE` directive is in scope, leading to context-dependent RDF terms. The change aligns Turtle with RDF 1.2 Concepts: IRI equality uses simple string comparison (no further normalization), while relative IRI references must be resolved against a base.

### Changes
- Add a normative **“Reference Resolution”** subsection under **IRIs**:
  - Absolute IRIs: use verbatim; no resolution/normalization.
  - Relative IRIs: resolve against base IRI as per RFC 3986 §5.1–§5.2.
- Add concise examples showing unchanged absolute IRIs and resolved relatives.
- Add an informative note referencing **RDF Reference IRIs** guidance for data publishers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/116.html" title="Last updated on Oct 24, 2025, 11:44 AM UTC (6fcf2e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/116/34f7c66...6fcf2e5.html" title="Last updated on Oct 24, 2025, 11:44 AM UTC (6fcf2e5)">Diff</a>