### PR TITLE
Dealing with pubrules and Gregg's editor status

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -32,13 +32,21 @@
       prevRecShortname:     "turtle",
 
       editors:  [
-        { name: "Gregg Kellogg", w3cid: "44770" },
+        {
+          name: "Gregg Kellogg",
+          w3cid: "44770",
+          //retiredDate: "2025-09-06", // Respec would automatically move Gregg to the 'Former Editors' section
+          note: "until 2025-09-06",
+          extras: [
+            {name: "in memoriam", class: "former"},
+          ],
+        },
         { name: "Dominik Tomaszuk", w3cid: "44239"},
       ],
 
       formerEditors:  [
-        { name: "Eric Prud&apos;hommeaux" },
-        { name: "Gavin Carothers" },
+        { name: "Eric Prud&apos;hommeaux" , note: "RDF 1.1" },
+        { name: "Gavin Carothers", note: "RDF 1.1" },
       ],
 
       // authors, add as many as you like.


### PR DESCRIPTION
See https://github.com/w3c/rdf-concepts/pull/247

>the W3C automated process requires all editors to be active W3C members;
we discussed with the chairs and other co-editors and this solution was proposed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/117.html" title="Last updated on Nov 6, 2025, 7:09 PM UTC (53307f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/117/34f7c66...53307f3.html" title="Last updated on Nov 6, 2025, 7:09 PM UTC (53307f3)">Diff</a>