### PR TITLE
Fix link text

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1951,7 +1951,7 @@
       <li id="curVersion">`xsd:string` |curVersion| –
         The RDF version used for parsing the document into <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">Triples</a>.
         If specified as part of a <a href="#sec-mediaReg">Media Type</a>, the default value for |curVersion| is taken from the `version` parameter.
-        Acceptable values for `version` are defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].
+        Acceptable values for `version` are defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].
         The version announcement is only a hint;
         this specification does not mandate any parser behavior based on |curVersion|,
         but a parser MAY signal an error or a warning
@@ -2409,7 +2409,7 @@
     <dd><code>charset</code> — this parameter is required when transferring non-ASCII data. If present, the value of <code>charset</code> is always <code>UTF-8</code>.</dd>
     <dd><code>version</code> — this parameter is optional but SHOULD be present when using RDF 1.2-specific features.
       If present, acceptable values of <code>version</code> are
-      defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Lables</a> in [[RDF12-CONCEPTS]].</dd>
+      defined in <a data-cite="RDF12-CONCEPTS#defined-version-labels">2.1 Version Labels</a> in [[RDF12-CONCEPTS]].</dd>
 
     <dt>Encoding considerations:</dt>
     <dd>The syntax of Turtle is expressed over code points in Unicode [[!UNICODE]]. The encoding is always UTF-8 [[!UTF-8]].</dd>


### PR DESCRIPTION
"Lable" -> "Label" *2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/119.html" title="Last updated on Dec 19, 2025, 8:56 AM UTC (42530b2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/119/405add3...42530b2.html" title="Last updated on Dec 19, 2025, 8:56 AM UTC (42530b2)">Diff</a>