### PR TITLE
GH-129: Fix XHTML example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2316,7 +2316,7 @@
       -->
     </pre>
 
-    <p>When embedded in XHTML Turtle data blocks must be enclosed in CDATA sections. Those CDATA markers must be in Turtle comments. If the character sequence <code>]]></code> occurs in the document it must be escaped using strings escapes (<code>\u005d\u0054\u003e</code>). This will also make Turtle safe in polyglot documents served as both <code>text/html</code>
+    <p>When embedded in XHTML Turtle data blocks must be enclosed in CDATA sections. Those CDATA markers must be in Turtle comments. If the character sequence <code>]]></code> occurs in the document it must be escaped using strings escapes (<code>\u005D\u005D\u003E</code>). This will also make Turtle safe in polyglot documents served as both <code>text/html</code>
     and <code>application/xhtml+xml</code>. Failing to use CDATA sections or escape <code>]]></code> may result in a non well-formed XML document.</p>
   </section>
 


### PR DESCRIPTION
This closes #129

`]]>` is `\u005D\u005D\u003E`

Uppercase, because this is preferred, and required for canonical N-triples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/132.html" title="Last updated on Apr 3, 2026, 10:54 AM UTC (bab12cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/132/880ac74...bab12cc.html" title="Last updated on Apr 3, 2026, 10:54 AM UTC (bab12cc)">Diff</a>