### PR TITLE
GH-131: Scalar value range for \u escape sequences

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1451,7 +1451,7 @@
                 <a href="#grammar-production-HEX"><code>hex</code></a></td>
               <td>A <a data-cite="I18N-GLOSSARY#dfn-code-point">Unicode code point</a>
                 in the ranges <code class="codepoint">U+0000</code> to <code class="codepoint">U+D7FF</code>
-                and <code class="codepoint">U+E000</code> to <code class="codepoint">U+D7FF</code>,
+                and <code class="codepoint">U+E000</code> to <code class="codepoint">U+FFFF</code>,
                 corresponding to the value encoded by the four hexadecimal digits interpreted
                 from most significant to least significant digit.</td>
             </tr>


### PR DESCRIPTION
See #131


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/133.html" title="Last updated on Apr 6, 2026, 1:19 PM UTC (d04e941)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/133/b97d883...d04e941.html" title="Last updated on Apr 6, 2026, 1:19 PM UTC (d04e941)">Diff</a>