### PR TITLE
Add content negotiation subsection

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -435,6 +435,60 @@
       </p>
     </div>
 
+    <section id="sec-version-conneg">
+      <h4>Syntax Version and Content Negotiation</h4>
+
+      <p>Just as HTTP servers can announce the syntax version of Turtle content
+        provided, HTTP clients can use the `version` media type parameter in
+        the `Accept` header, for the purpose of
+        <a data-cite="RFC9110#section-12.5.1">Content Negotiation</a>,
+        as follows:</p>
+      <pre id="ex-http-version-request"
+          class="example http" data-transform="updateExample"
+          title="HTTP content negotation for Turtle using version parameter">
+        <!--
+        GET /document HTTP/1.1
+        Host: example.com
+        Accept: text/turtle; version=1.2
+        -->
+      </pre>
+
+      <p>Note that the accept header of a client does not have to make use of
+        the `version` media type parameter. A request can simply look like:</p>
+      <pre id="ex-http-versionless-request"
+          class="example http" data-transform="updateExample"
+          title="HTTP content negotation for Turtle without version parameter">
+        <!--
+        GET /document HTTP/1.1
+        Host: example.com
+        Accept: text/turtle
+        -->
+      </pre>
+      <p>This carries no implication about the parsing capabilities of the
+        client. However, since the client doesn't advertise what version of
+        Turtle it is capable of parsing, a server might be conservative
+        here and explicitly serve 1.1 content instead:</p>
+      <pre id="ex-http-version-11-response"
+          class="example http" data-transform="updateExample"
+          title="HTTP response announcing Turtle version 1.1 response">
+        <!--
+        HTTP/1.1 200 OK
+        Content-Type: text/turtle; version=1.1
+        Content-Location: https://example.com/document-basic.ttl
+        -->
+      </pre>
+      <p>Note that while content negotiation follows clear rules, it is a "best
+        available" design, and a server is free to simply serve what it has,
+        without regard for the version parameter. The specific circumstances
+        leading to a conservative response, as above, are beyond the scope of
+        this document to define. Other services might, for example,
+        conditionally serve different syntaxes when the `version` parameter is
+        used in combination with the `q`
+        <a data-cite="RFC9110#section-12.4.2">media type preference</a>
+        parameter, or unconditionally serve Turtle 1.2 syntax.</p>
+
+    </section>
+
   </section>
 
   <section id="sec-iri">

--- a/spec/index.html
+++ b/spec/index.html
@@ -389,13 +389,13 @@
     <p>When providing content over HTTP, servers can announce the version
       using the optional `version` <a href="#sec-mediaReg">Media Type parameter</a>:</p>
 
-    <pre id="ex-http-version-decl"
-         class="example turtle" data-transform="updateExample"
-         title="HTTP version announcement">
+    <pre id="ex-http-version-12-response"
+         class="example http" data-transform="updateExample"
+         title="HTTP response announcing Turtle version 1.2 response">
       <!--
-      GET /document.ttl HTTP/1.1
-      Host: example.com
-      Accept: text/turtle; version=1.2
+      HTTP/1.1 200 OK
+      Content-Type: text/turtle; version=1.2
+      Content-Location: https://example.com/document.ttl
       -->
     </pre>
 
@@ -434,6 +434,7 @@
         as it would needlessly cause Turtle 1.1 parsers to fail.
       </p>
     </div>
+
   </section>
 
   <section id="sec-iri">


### PR DESCRIPTION
This does two things:

1. Fixes the incorrect example about version announcement, which currently uses the `Accept` HTTP *request* header as an example of a server announcing the version of a turtle document being served. That is a *response*, and needs to use the `Content-Type` HTTP *response* header to provide information about the media type being served.

2. Adds information about syntax versioning and content negotiation on the web. Should this rather go elsewhere; e.g. in RDF Concepts? It is rather technical, and probably better suited in a concrete syntax document. On the other hand, this same reasoning goes for the other syntaxes as well. Is it OK for them to link to this section in the Turtle spec?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/135.html" title="Last updated on Apr 22, 2026, 8:26 AM UTC (3b35ce9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/135/b4dd46c...3b35ce9.html" title="Last updated on Apr 22, 2026, 8:26 AM UTC (3b35ce9)">Diff</a>