### PR TITLE
Fix version HTTP response example

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -395,7 +395,6 @@
       <!--
       HTTP/1.1 200 OK
       Content-Type: text/turtle; version=1.2
-      Content-Location: https://example.com/document.ttl
       -->
     </pre>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -389,13 +389,13 @@
     <p>When providing content over HTTP, servers can announce the version
       using the optional `version` <a href="#sec-mediaReg">Media Type parameter</a>:</p>
 
-    <pre id="ex-http-version-decl"
-         class="example turtle" data-transform="updateExample"
-         title="HTTP version announcement">
+    <pre id="ex-http-version-12-response"
+         class="example http" data-transform="updateExample"
+         title="HTTP response announcing Turtle version 1.2 response">
       <!--
-      GET /document.ttl HTTP/1.1
-      Host: example.com
-      Accept: text/turtle; version=1.2
+      HTTP/1.1 200 OK
+      Content-Type: text/turtle; version=1.2
+      Content-Location: https://example.com/document.ttl
       -->
     </pre>
 


### PR DESCRIPTION
This fixes the incorrect example about version announcement, which currently uses the `Accept` HTTP *request* header as an example of a server announcing the version of a turtle document being served. That is a *response*, and needs to use the `Content-Type` HTTP response header to provide information about the media type being served.

(This is the fix from https://github.com/w3c/rdf-turtle/pull/135 which also proposes additional text about content negotiation.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/136.html" title="Last updated on Apr 20, 2026, 7:53 PM UTC (52eee8b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/136/b4dd46c...52eee8b.html" title="Last updated on Apr 20, 2026, 7:53 PM UTC (52eee8b)">Diff</a>