### PR TITLE
Clarify reifier use in annotation syntax

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1260,7 +1260,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with multiple explicit Reifiers expanded">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
       :alice :name "Alice" .

--- a/spec/index.html
+++ b/spec/index.html
@@ -1206,7 +1206,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with multiple implicit Reifiers">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
       :alice :name "Alice"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1145,7 +1145,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple expanded to Triple Terms">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1170,7 +1170,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with an implicit Reifier">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
       :alice :name "Alice" {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .

--- a/spec/index.html
+++ b/spec/index.html
@@ -1129,7 +1129,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple expanded to Reifiers">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
       :alice :name "Alice" .

--- a/spec/index.html
+++ b/spec/index.html
@@ -1185,7 +1185,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with an implicit Reifier expanded">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1081,17 +1081,29 @@
         <a data-cite="RDF12-CONCEPTS#dfn-subject">subject</a> or
         <a data-cite="RDF12-CONCEPTS#dfn-object">object</a> of additional
         triples and/or <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>.
-        As with a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>,
-        the annotation syntax allows the definition of
-        one or more <a>reifiers</a> as either <a data-cite="RDF12-CONCEPTS#dfn-iri">IRIs</a>
-        or <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank nodes</a>,
-        each preceded by a tilde (<a href="#cp-tilde"><code title="tilde">~</code></a>),
-        which precedes the annotation block.
-        If not followed by an annotation block, a <a>reifier</a>
-        is treated like a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-        without annotations.
+      </p>
+
+      <p>Like a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>,
+        the annotation syntax uses a <a>reifier</a>, written as either an
+        <a data-cite="RDF12-CONCEPTS#dfn-iri">IRI</a> or a
+        <a data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</a>,
+        preceded by a tilde (<a href="#cp-tilde"><code title="tilde">~</code></a>),
+        to identify the
+        <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a> being reified.
+        However, while a
+        <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        may contain at most one <a>reifier</a>, the annotation syntax may contain
+        any number of <a>reifiers</a>. Each <a>reifier</a> causes a corresponding
+        reifying triple to be produced.
+      </p>
+
+      <p>A <a>reifier</a> may be followed by an annotation block.
+        If a <a>reifier</a> is not followed by an annotation block, it is treated
+        analogously to a
+        <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        without additional annotations.
         If an annotation block is not immediately preceded by a <a>reifier</a>,
-        an RDF blank node is allocated to serve as the <a>reifier</a> of the
+        a fresh RDF blank node is allocated to serve as the <a>reifier</a> of the
         <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
       </p>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1109,7 +1109,8 @@
 
       <p class="note">The annotation syntax is a syntactic shortcut in Turtle,
 <p class="note">The annotation syntax is a syntactic shortcut in Turtle.
-The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
+      <p class="note">The annotation syntax is a syntactic shortcut in Turtle.
+        The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
         distinguish how the triples were written.</p>
 
       <pre id="ex-annotated-triple"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1223,7 +1223,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with multiple implicit Reifiers expanded">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1108,7 +1108,8 @@
       </p>
 
       <p class="note">The annotation syntax is a syntactic shortcut in Turtle,
-        and the RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
+<p class="note">The annotation syntax is a syntactic shortcut in Turtle.
+The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
         distinguish how the triples were written.</p>
 
       <pre id="ex-annotated-triple"

--- a/spec/index.html
+++ b/spec/index.html
@@ -1117,7 +1117,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
       :alice :name "Alice" ~ :t {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .

--- a/spec/index.html
+++ b/spec/index.html
@@ -1246,7 +1246,7 @@ The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
            title="Annotated Triple with multiple explicit Reifiers">
       <!--
       VERSION     "1.2"
-      PREFIX : <http://example.com/>
+      PREFIX :    <http://example.com/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
       :alice :name "Alice" ~ :stmt1 ~ :stmt2 .

--- a/spec/index.html
+++ b/spec/index.html
@@ -1112,50 +1112,162 @@
         distinguish how the triples were written.</p>
 
       <pre id="ex-annotated-triple"
-           class="example turtle" data-transform="updateExample" 
+           class="example turtle" data-transform="updateExample"
            title="Annotated Triple">
-        <!--
-        VERSION     "1.2"
-        PREFIX : <http://example.com/>
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-        :a :name "Alice" ~ :t {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .
-          -->
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" ~ :t {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .
+      -->
       </pre>
       <p>is the same set of triples as:</p>
       <pre id="ex-annotated-triple-expanded-to-reifiers"
            class="example turtle" data-transform="updateExample"
            title="Annotated Triple expanded to Reifiers">
-        <!--
-        VERSION     "1.2"
-        PREFIX : <http://example.com/>
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-        :a :name "Alice" .
-        << :a :name "Alice" ~ :t >> :statedBy :bob ;
-                                    :recorded "2021-07-07"^^xsd:date .
-         -->
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" .
+      << :alice :name "Alice" ~ :t >> :statedBy :bob ;
+                                      :recorded "2021-07-07"^^xsd:date .
+      -->
       </pre>
 
-      <p>and the graph contains three <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triples</a>.
-        The <a>reifier</a> is identified by `:t`.</p>
-
-      <p>Fully expanding to use <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>, instead of reifiers, results in the following:</p>
+      <p>Fully expanding to use <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple terms</a>,
+        instead of reifiers, results in the following:</p>
       <pre id="ex-annotated-triple-expanded-to-triple-terms"
            class="example turtle" data-transform="updateExample"
            title="Annotated Triple expanded to Triple Terms">
-        <!--
-        VERSION     "1.2"
-        PREFIX : <http://example.com/>
-        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-        :a :name "Alice" .
-        :t rdf:reifies <<( :a :name "Alice" )>> .
-        :t :statedBy :bob .
-        :t :recorded "2021-07-07"^^xsd:date .
-         -->
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" .
+      :t rdf:reifies <<( :alice :name "Alice" )>> .
+      :t :statedBy :bob .
+      :t :recorded "2021-07-07"^^xsd:date .
+      -->
       </pre>
 
-      <p class="note">An <a href="#grammar-production-annotation"><code>annotation</code></a> can include any number of <a>reifiers</a>.</p>
-      
+      <p>In the previous example, the graph contains four
+      <a data-cite="RDF12-CONCEPTS#dfn-rdf-triple">triples</a>.
+      The <a>reifier</a> is identified by <code>:t</code>.</p>
+
+      <p>The annotation block may also be used without an explicit
+        <a>reifier</a>. In that case, a fresh RDF blank node is allocated
+        to serve as the <a>reifier</a> of the
+        <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.</p>
+
+      <pre id="ex-annotated-triple-implicit-reifier"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with an implicit Reifier">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .
+      -->
+      </pre>
+
+      <p>Fully expanding this example results in the following triples, where
+        <code>_:b0</code> stands for a fresh RDF blank node:</p>
+
+      <pre id="ex-annotated-triple-implicit-reifier-expanded"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with an implicit Reifier expanded">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" .
+      _:b0 rdf:reifies <<( :alice :name "Alice" )>> .
+      _:b0 :statedBy :bob .
+      _:b0 :recorded "2021-07-07"^^xsd:date .
+      -->
+      </pre>
+
+      <p>An <a href="#grammar-production-annotation"><code>annotation</code></a>
+        may include any number of annotation blocks. If such blocks are not
+        immediately preceded by explicit <a>reifiers</a>, each block is associated
+        with a fresh RDF blank node allocated as its <a>reifier</a>.</p>
+
+      <pre id="ex-annotated-triple-multiple-implicit-reifiers"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with multiple implicit Reifiers">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice"
+        {| :statedBy :alice ; :recorded "2017-02-01"^^xsd:date |}
+        {| :statedBy :bob ; :recorded "2021-07-07"^^xsd:date |} .
+      -->
+      </pre>
+
+      <p>Fully expanding this example results in the following triples, where
+        <code>_:b0</code> and <code>_:b1</code> stand for fresh RDF blank nodes:</p>
+
+      <pre id="ex-annotated-triple-multiple-implicit-reifiers-expanded"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with multiple implicit Reifiers expanded">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+      :alice :name "Alice" .
+      _:b0 rdf:reifies <<( :alice :name "Alice" )>> .
+      _:b0 :statedBy :alice .
+      _:b0 :recorded "2017-02-01"^^xsd:date .
+      _:b1 rdf:reifies <<( :alice :name "Alice" )>> .
+      _:b1 :statedBy :bob .
+      _:b1 :recorded "2021-07-07"^^xsd:date .
+      -->
+      </pre>
+
+      <p>The annotation syntax may also contain multiple explicit
+        <a>reifiers</a> without annotation blocks. Each such <a>reifier</a>
+        causes a corresponding reifying triple to be produced.</p>
+
+      <pre id="ex-annotated-triple-multiple-reifiers"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with multiple explicit Reifiers">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+      :alice :name "Alice" ~ :stmt1 ~ :stmt2 .
+      -->
+      </pre>
+
+      <p>Fully expanding this example results in the following triples:</p>
+
+      <pre id="ex-annotated-triple-multiple-reifiers-expanded"
+           class="example turtle" data-transform="updateExample"
+           title="Annotated Triple with multiple explicit Reifiers expanded">
+      <!--
+      VERSION     "1.2"
+      PREFIX : <http://example.com/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+      :alice :name "Alice" .
+      :stmt1 rdf:reifies <<( :alice :name "Alice" )>> .
+      :stmt2 rdf:reifies <<( :alice :name "Alice" )>> .
+      -->
+      </pre>
+
     </section>
 
   </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1107,8 +1107,6 @@
         <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>.
       </p>
 
-      <p class="note">The annotation syntax is a syntactic shortcut in Turtle,
-<p class="note">The annotation syntax is a syntactic shortcut in Turtle.
       <p class="note">The annotation syntax is a syntactic shortcut in Turtle.
         The RDF Abstract Syntax [[RDF11-CONCEPTS]] does not
         distinguish how the triples were written.</p>


### PR DESCRIPTION
## Summary

This PR clarifies the wording in the Annotation Syntax section regarding the use of reifiers.

The previous wording could be read as implying that `reifiedTriple` allows one or more reifiers. However, the grammar distinguishes the two cases:

- `reifiedTriple` may contain at most one optional `reifier`;
- annotation syntax may contain any number of `reifier` occurrences.

The updated text makes this distinction explicit and states that each reifier in annotation syntax causes a corresponding reifying triple to be produced.

## Changes

- Split the existing paragraph for readability.
- Clarified that `reifiedTriple` may contain at most one reifier.
- Clarified that annotation syntax may contain any number of reifiers.
- Rephrased the treatment of a reifier not followed by an annotation block.
- Clarified that a fresh blank node is allocated when an annotation block is not immediately preceded by a reifier.

## Related issue

Addresses #109.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/137.html" title="Last updated on Apr 28, 2026, 6:36 PM UTC (4aefdd0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/137/559fa06...4aefdd0.html" title="Last updated on Apr 28, 2026, 6:36 PM UTC (4aefdd0)">Diff</a>