### PR TITLE
Consistent 'Turtle document'

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1532,7 +1532,7 @@
   <section id="sec-escapes">
     <h3>Escape Sequences</h3>
 
-    <p>There are three forms of escapes used in turtle documents:</p>
+    <p>There are three forms of escapes used in Turtle documents:</p>
 
     <ul>
       <li>


### PR DESCRIPTION
A one bit PR.

There was one use of "turtle document", all the others are "Turtle document".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/139.html" title="Last updated on May 1, 2026, 5:21 PM UTC (c347f08)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/139/4ce35bd...c347f08.html" title="Last updated on May 1, 2026, 5:21 PM UTC (c347f08)">Diff</a>