### PR TITLE
Lighter background color for the "Context where each kind of escape sequence can be used" table

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -140,6 +140,9 @@
     table.cp-definitions th,
     table.cp-definitions td { border:0px solid black; padding:0.2em; }
     table.cp-definitions td:nth-child(2) { text-align: center; }
+
+    .term2escape-yes { background-color: lightgreen; }
+    .darkmode .term2escape-yes { background-color: darkgreen; }
   </style> 
 </head>
 
@@ -1693,7 +1696,7 @@
           <a href="#grammar-production-sparqlPrefix"><code>PREFIX</code></a>,
           <a href="#grammar-production-base"><code>@base</code></a>,
           or <a href="#grammar-production-sparqlBase"><code>BASE</code></a> declarations</td>
-        <td style="background-color: lightgreen; border:1px solid black;">yes</td>
+        <td class="term2escape-yes">yes</td>
         <td>no</td>
         <td>no</td>
       </tr>
@@ -1701,12 +1704,12 @@
         <td class="r"><a href="#grammar-production-PN_LOCAL"><span style="font-weight:bold;">local name</span>s</a></td>
         <td>no</td>
         <td>no</td>
-        <td style="background-color: lightgreen; border:1px solid black;">yes</td>
+        <td class="term2escape-yes">yes</td>
       </tr>
       <tr>
         <td class="r"><span style="font-weight:bold;">String</span>s</td>
-        <td style="background-color: lightgreen; border:1px solid black;">yes</td>
-        <td style="background-color: lightgreen; border:1px solid black;">yes</td>
+        <td class="term2escape-yes">yes</td>
+        <td class="term2escape-yes">yes</td>
         <td>no</td>
       </tr>
       </tbody>


### PR DESCRIPTION
<img width="1626" height="460" alt="Screenshot 2026-05-14 at 22-07-33 RDF 1 2 Turtle" src="https://github.com/user-attachments/assets/422c84cc-f489-4d5e-afde-13e1b87ba868" />
<img width="1632" height="476" alt="Screenshot 2026-05-14 at 22-07-23 RDF 1 2 Turtle" src="https://github.com/user-attachments/assets/9135f82c-d088-427b-a249-bd0830ecbbe1" />


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/140.html" title="Last updated on May 14, 2026, 8:08 PM UTC (3de6dd7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/140/3425342...3de6dd7.html" title="Last updated on May 14, 2026, 8:08 PM UTC (3de6dd7)">Diff</a>