### PR TITLE
Add dfn and links for Turtle documents and Turtle parsers

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1419,13 +1419,13 @@
   <p>This specification defines conformance criteria for:</p>
 
   <ul>
-    <li>Turtle documents</li>
-    <li>Turtle parsers</li>
+    <li><a>Turtle documents</a></li>
+    <li><a>Turtle parsers</a></li>
   </ul>
 
   <p>A conforming <dfn>Turtle document</dfn> is an <a data-cite="RDF12-CONCEPTS#dfn-rdf-string">RDF string</a> that conforms to the grammar and additional constraints defined in <a href="#sec-grammar" class="sectionRef"></a>, starting with the <a href="#grammar-production-turtleDoc"><code>turtleDoc</code></a> production. A <a>Turtle document</a> serializes an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a>.</p>
 
-  <p>A conforming <strong>Turtle parser</strong> is a system capable of reading Turtle documents on behalf of an application.
+  <p>A conforming <dfn>Turtle parser</dfn> is a system capable of reading <a>Turtle documents</a> on behalf of an application.
     It makes the serialized RDF graph, as defined in <a href="#sec-parsing" class="sectionRef"></a>,
     available to the application, usually through some form of API.</p>
 


### PR DESCRIPTION
The conformance section didn't have links (NT and NQ do).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/142.html" title="Last updated on May 17, 2026, 2:40 PM UTC (38dd56b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/142/2774cf1...38dd56b.html" title="Last updated on May 17, 2026, 2:40 PM UTC (38dd56b)">Diff</a>