### PR TITLE
GH-146: Character set is always UTF-8

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1437,11 +1437,7 @@
     <h2>Media Type and Content Encoding</h2>
 
     <p>The media type of Turtle is <code>text/turtle</code>.
-    The content encoding of Turtle content is always UTF-8 [[!RFC3629]].
-    Charset parameters on the media type are required until such time as the
-    <code>text/</code> media type tree permits UTF-8 to be sent without a
-    charset parameter. See <a href="#sec-mediaReg" class="sectionRef"></a> for the media type
-    registration form.
+      The content encoding of Turtle content is always UTF-8 [[!RFC3629]].
     </p>
   </section>
 </section>
@@ -2609,12 +2605,6 @@
     <dt>Optional parameters:</dt>
     <dd>
       <dl>
-        <dt><code>charset</code></dt>
-        <dd>
-          This parameter is required when transferring non-ASCII data.
-          If present, the value of <code>charset</code> is always <code>UTF-8</code>.
-        </dd>
-
         <dt><code>version</code></dt>
         <dd>
           This parameter is optional.
@@ -2788,6 +2778,7 @@
     <li>Added the optional <code>profile</code> media type parameter
       to allow clients and servers to convey additional profile information
       for Turtle representations without changing their semantics.</li>
+    <li>Update media registration now that UTF-8 can be required for text/.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
This closes #146.

See [RFC 6657, section 3](https://datatracker.ietf.org/doc/html/rfc6657#section-3) which allows media types in text/* to define their encoding. 

Strict RDF 1.1 clients are compatible.

Text is now the same in TriG, N_Quads and N-Triples.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/147.html" title="Last updated on May 28, 2026, 9:53 AM UTC (b4510b0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/147/d562e2d...b4510b0.html" title="Last updated on May 28, 2026, 9:53 AM UTC (b4510b0)">Diff</a>