### PR TITLE
state that Turtle 1.2 is not ambiguous for 1.1 implems

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -248,7 +248,7 @@
   </p>
 
   <p>
-    This version of Turtle is fully backward compatible with the previous version [[?TURTLE]].
+    This version of Turtle is fully syntactically and semantically backward compatible with the previous version [[[?TURTLE]]].
   </p>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -207,6 +207,7 @@
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX rel: <http://www.perceive.net/schemas/relationship/>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
     <#green-goblin>
       rel:enemyOf <#spiderman> ;
@@ -216,18 +217,20 @@
     <#spiderman>
       rel:enemyOf <#green-goblin> ;
       a foaf:Person ;
-      foaf:name "Spiderman", "Человек-паук"@ru .
+      foaf:name "Spiderman",
+       "الرجل العنكبوت"@ar--rtl {| dct:source <https://www.wikidata.org/> |}.
     -->
   </pre>
 
   <p>
-    This example introduces many of features of the Turtle language:
+    This example introduces many features of the Turtle language:
     <a href="#relative-iri">BASE and Relative IRI references</a>,
     <a href="#prefixed-name">PREFIX and prefixed names</a>,
     <a href="#predicate-lists">predicate lists</a> separated by <a href="#cp-semicolon"><code title="semicolon">;</code></a>,
     <a href="#object-lists">object lists</a> separated by <a href="#cp-comma"><code title="comma">,</code></a>,
     the token <a href="#iri-a"><code>a</code></a>,
-    and <a href="#literals">literals</a>.
+    <a href="#literals">literals</a>,
+    and <a href="#annotation-syntax">annotations</a>.
   </p>
 
   <p>
@@ -242,6 +245,10 @@
     The construction of an <a data-cite="RDF12-CONCEPTS#dfn-rdf-graph">RDF graph</a> from a <a>Turtle document</a> is defined in
     <a href="#sec-grammar" class="sectionRef">Turtle Grammar</a>
     and <a href="#sec-parsing" class="sectionRef">Parsing</a>.
+  </p>
+
+  <p>
+    This version of Turtle is fully backward compatible with the previous version [[?TURTLE]].
   </p>
 </section>
 
@@ -2754,6 +2761,19 @@
 <section class="appendix informative" id="changes-12">
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
+  <p>
+      This specification extends the original Turtle syntax, as defined in [[TURTLE]], to support the new features introduced by [[RDF12-CONCEPTS]].
+      This extension is fully backward compatible:
+      any document complying with the old version complies with the new version, and parses to the same graph.
+      Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version
+      (with the exception of the `VERSION` directive; see <a href="#sec-version"></a>).
+      Finally, none of the new syntactic constructs are valid in the old syntax.
+      This means that any Turtle document using RDF 1.2 features does not
+      comply with the previous version of this specification and cannot be
+      interpreted as a different graph under it.
+  </p>
+
+  <p>More specifically, the following changes have been made:</p>
   <ul>
     <li>Update informative restrictions on included characters for `STRING_LITERAL_QUOTE`
       and `STRING_LITERAL_SINGLE_QUOTE`.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2762,7 +2762,7 @@
   <h2>Changes between RDF 1.1 and RDF 1.2</h2>
 
   <p>
-      This specification extends the original Turtle syntax, as defined in [[TURTLE]], to support the new features introduced by [[RDF12-CONCEPTS]].
+      This specification extends the original Turtle syntax, as defined in [[[TURTLE]]], to support the new features introduced by [[[RDF12-CONCEPTS]]].
       This extension is fully backward compatible:
       any document complying with the old version complies with the new version, and parses to the same graph.
       Furthermore, any document complying with the new version and containing only RDF 1.1 features is also compliant with the older version


### PR DESCRIPTION
also adapt the introductory example to include Turtle 1.2 features.

this PR is largely inspired by w3c/rdf-n-triples#90 and w3c/rdf-n-triples#105.

Fix #125


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/148.html" title="Last updated on Jun 4, 2026, 2:26 PM UTC (d39593d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/148/a84ef51...d39593d.html" title="Last updated on Jun 4, 2026, 2:26 PM UTC (d39593d)">Diff</a>