### PR TITLE
Version fix

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -422,7 +422,7 @@
 
     <p>
      In the absence of a current version directive, any version specified as part of the <a href="#sec-mediaReg">Media Type</a> is considered.
-      In any case, the version announcement is merely a hint;
+      In any case, the version announcement is a hint;
       parsers are not required to reject features that are outside the announced version
       (but could signal them with a warning).
     </p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -411,9 +411,9 @@
       This allows parsers that do not support these features to detect
       the presense of such features early, and potentially 
       inform the user, giving them an opportunity to stop the job
-      or otherwise act on the fact that the input data 
-      will not be entirely processed.
-    </p>
+      or otherwise act on the fact that the output data 
+      may be a subset of the intended output.
+</p>
 
     <p>Multiple version directives may appear in a Turtle document.
     The directive applies to the part of the document following the directive,

--- a/spec/index.html
+++ b/spec/index.html
@@ -409,7 +409,7 @@
       or <a href="#grammar-production-version"><code>@version</code></a>
       directives early in the document.
       This allows parsers that do not support these features to detect
-      the presense of such features early, and potentially 
+      their possible presence early on, and potentially 
       inform the user, giving them an opportunity to stop the job
       or otherwise act on the fact that the output data 
       may be a subset of the intended output.

--- a/spec/index.html
+++ b/spec/index.html
@@ -411,8 +411,8 @@
       This allows parsers that do not support these features to detect
       the presense of such features early, and potentially 
       inform the user, giving them an opportunity to stop the job
-      or otherwise act on the fact that some amount of the input data 
-      will not be processed as desired.
+      or otherwise act on the fact that the input data 
+      will not be entirely processed.
     </p>
 
     <p>Multiple version directives may appear in a Turtle document.

--- a/spec/index.html
+++ b/spec/index.html
@@ -412,7 +412,7 @@
       their possible presence early on, and potentially 
       inform the user, giving them an opportunity to stop the job
       or otherwise act on the fact that the output data 
-      may be a subset of the intended output.
+      may be a subset of the anticipated output.
 </p>
 
     <p>Multiple version directives may appear in a Turtle document.

--- a/spec/index.html
+++ b/spec/index.html
@@ -422,7 +422,6 @@
 
     <p>
      In the absence of a current version directive, any version specified as part of the <a href="#sec-mediaReg">Media Type</a> is considered.
-     In the absence of any version information, a sensible default is `"1.1"`, to maximize compatibility with the previous version of Turtle [[TURTLE]].
       In any case, the version announcement is merely a hint;
       parsers are not required to reject features that are outside the announced version
       (but could signal them with a warning).


### PR DESCRIPTION
* [reword remark on unrecognized version](https://github.com/w3c/rdf-turtle/commit/7d9174f15556a1ff50b2ba10e8fad3f73f03abe1)

the previous wording seemed to imply that new features could be *misinterpreted*,
which is not the case.

* [remove confusing remark about 'sensible default'](https://github.com/w3c/rdf-turtle/commit/6ab938c0a57dc4c67b878f58e5a2b1359c1de5de)

This is indeed contradicting other pieces of advices in RDF Concept.
For servers, 1.1 is a sensible default in the absence of version in the Accept header,
but for clients, 1.2 is a sensible default in the absence of version in the received data.

Just removed it. The detail above is contained in https://github.com/w3c/rdf-concepts/pull/280


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/150.html" title="Last updated on Jul 23, 2026, 4:44 PM UTC (64753c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/150/a84ef51...64753c4.html" title="Last updated on Jul 23, 2026, 4:44 PM UTC (64753c4)">Diff</a>