### PR TITLE
Update references to Collections and Reification vocabulary

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -901,7 +901,7 @@
     <h3>Collections</h3>
 
     <p>
-      RDF provides a <a data-cite="RDF12-SEMANTICS#rdf-collections">Collection</a> [[RDF12-SEMANTICS]]
+      RDF provides a <a data-cite="RDF12-SCHEMA#ch_collectionvocab">Collection</a> [[RDF12-SCHEMA]]
       structure for lists of RDF nodes.
       The Turtle syntax for Collections is a possibly empty list of <a data-cite="RDF12-CONCEPTS#dfn-rdf-term">RDF terms</a> enclosed by <a href="#cp-paren-left"><code title="left parenthesis">(</code></a><a href="#cp-paren-right"><code title="right parenthesis">)</code></a>.
       This collection represents an <code>rdf:first</code>/<code>rdf:rest</code>
@@ -985,7 +985,7 @@
       may or may not be asserted within the graph corresponding to this input document.</p>
 
     <p class="note">Reification in RDF 1.2 is a concept distinct from the
-      <a data-cite="RDF12-SEMANTICS#Reif">Reification vocabulary</a> originally
+      <a data-cite="RDF12-SCHEMA#ch_reificationvocab">Reification vocabulary</a> originally
       defined in <a data-cite="RDF-MT#Reif">RDF Semantics</a>.
       While both terms describe a representation of an RDF triple using components,
       RDF 1.2 uses the term to identify a <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>


### PR DESCRIPTION
Adjust references to point to their new locations in RDF 1.2 Schema: RDF Collections and "Old-style" Reification.

see https://github.com/w3c/rdf-turtle/issues/151


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/156.html" title="Last updated on Aug 6, 2026, 10:20 AM UTC (b4f628c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/156/6bc3548...b4f628c.html" title="Last updated on Aug 6, 2026, 10:20 AM UTC (b4f628c)">Diff</a>