### PR TITLE
Move the reifiedTriple syntactic sugar explanation into the note

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1055,7 +1055,10 @@
       -->
     </pre>
 
-    <p class="note">Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+    <p class="note">A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> is syntactic sugar relating a
+      <a>reifier</a> to a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
+      using the <code>rdf:reifies</code> predicate.
+      Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
       (i.e., `&lt;&lt; [...] >>`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> (i.e., `&lt;&lt;( [...] )>>`).</p>
 
     <p>After declaring a prefix so that IRIs can be abbreviated,
@@ -1065,10 +1068,6 @@
       In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
       is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
       rather, it is known as a <a>reifying triple</a>.</p>
-
-    <p>A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> is syntactic sugar relating a
-      <a>reifier</a> to a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
-      using the <code>rdf:reifies</code> predicate.</p>
 
     <section id="annotation-syntax">
       <h2>Annotation Syntax</h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1053,7 +1053,8 @@
 <p>After declaring a prefix so that IRIs can be abbreviated,
 the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
 Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";
-it says that `employee22` has made that claim using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
+rather, it says that `employee22` has made that claim
+using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
 In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
 is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
 instead, it is known as a <a>reifying triple</a>.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1043,6 +1043,7 @@
          title="Reified Triple expanded to Triple Term">
       <!--
       PREFIX :    <http://www.example.org/>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
       :employee38 :familyName "Smith" .
       _:id rdf:reifies <<( :employee38 :jobTitle "Assistant Designer" )>> .
@@ -1050,24 +1051,22 @@
       -->
     </pre>
 
-<p>After declaring a prefix so that IRIs can be abbreviated,
-the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
-Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";
-rather, it says that `employee22` has made that claim
-using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
-In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
-is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
-instead, it is known as a <a>reifying triple</a>.</p>
+    <p>Each of the examples above asserts that `:employee38` has a `:familyName` of "Smith".
+      None of the examples asserts that `:employee38` has a `:jobTitle` of "Assistant Designer".
+      Instead, the latter triple is used as a
+      <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
+      which is the object of a <a>reifying triple</a>.
+      The <a>reifier</a> is related to `:employee22` using `:accordingTo`.</p>
 
     <div class="note">
-    <p>Note the difference
-      in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-      <br>(i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
-      <br>(i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
-     <p class="note"><a href="#grammar-production-reifiedTriple"><code>reifiedTriples</code></a> may be nested,
-      like
-      <br/>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`
-      or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 :object3 ~:IRIREF3 &gt;&gt; &gt;&gt;`.</p>
+      <p>Note the difference
+        in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        <br>(i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
+        <br>(i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
+      <p>A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        may be nested inside another, as in
+        <br>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`
+        or <br>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 :object3 ~:IRIREF3 &gt;&gt; &gt;&gt;`.</p>
     </div>
 
     <section id="annotation-syntax">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1057,18 +1057,24 @@
 
     <p class="note">A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
       is syntactic sugar that uses the <code>rdf:reifies</code> predicate to relate a <a>reifier</a>
-      to a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>. Note the difference
+<p>After declaring a prefix so that IRIs can be abbreviated,
+the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
+Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";
+it says that `employee22` has made that claim using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
+In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
+is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
+rather, it is known as a <a>reifying triple</a>.</p>
+
+    <div class="note">
+    <p>Note the difference
       in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
       (i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
       (i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
-
-    <p>After declaring a prefix so that IRIs can be abbreviated,
-      the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
-      Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";
-      it says that `employee22` has made that claim using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
-      In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
-      is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
-      rather, it is known as a <a>reifying triple</a>.</p>
+     <p class="note"><a href="#grammar-production-reifiedTriple"><code>reifiedTriples</code></a> may be nested,
+      like
+      <br/>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`
+      or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 :object3 ~:IRIREF3 &gt;&gt; &gt;&gt;`.</p>
+    </div>
 
     <section id="annotation-syntax">
       <h2>Annotation Syntax</h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1011,11 +1011,6 @@
       as with `&lt;&lt; :subject :predicate :object &gt;&gt;`,
       or `&lt;&lt; :subject :predicate :object ~ &gt;&gt;`.</p>
 
-    <p class="note"><a href="#grammar-production-reifiedTriple"><code>reifiedTriples</code></a> may be nested,
-      like
-      <br/>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`
-      or <br/>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 :object3 ~:IRIREF3 &gt;&gt; &gt;&gt;`.</p>
-
     <pre id="ex-reified-triple"
          class="example turtle" data-transform="updateExample"
          title="Reified Triple">
@@ -1055,8 +1050,6 @@
       -->
     </pre>
 
-    <p class="note">A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-      is syntactic sugar that uses the <code>rdf:reifies</code> predicate to relate a <a>reifier</a>
 <p>After declaring a prefix so that IRIs can be abbreviated,
 the first triple in this example asserts that `employee38` has a `familyName` of "Smith".
 Note that this graph does not assert that `employee38` has a `jobTitle` of "Assistant Designer";

--- a/spec/index.html
+++ b/spec/index.html
@@ -1062,8 +1062,8 @@ instead, it is known as a <a>reifying triple</a>.</p>
     <div class="note">
     <p>Note the difference
       in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-      (i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
-      (i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
+      <br>(i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
+      <br>(i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
      <p class="note"><a href="#grammar-production-reifiedTriple"><code>reifiedTriples</code></a> may be nested,
       like
       <br/>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`

--- a/spec/index.html
+++ b/spec/index.html
@@ -1056,7 +1056,7 @@ Note that this graph does not assert that `employee38` has a `jobTitle` of "Assi
 it says that `employee22` has made that claim using a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>.
 In other words, the triple "`employee38` has a `jobTitle` of 'Assistant Designer'"
 is not a member of the graph, itself, as "employee38 has a `familyName` of 'Smith'" is above;
-rather, it is known as a <a>reifying triple</a>.</p>
+instead, it is known as a <a>reifying triple</a>.</p>
 
     <div class="note">
     <p>Note the difference

--- a/spec/index.html
+++ b/spec/index.html
@@ -1053,7 +1053,7 @@
 
     <p>Each of the examples above asserts that `:employee38` has a `:familyName` of "Smith".
       None of the examples asserts that `:employee38` has a `:jobTitle` of "Assistant Designer".
-      Instead, the latter triple is used as a
+      Rather, the latter triple is used as a
       <a data-cite="RDF12-CONCEPTS#dfn-triple-term">triple term</a>,
       which is the object of a <a>reifying triple</a>.
       The <a>reifier</a> is related to `:employee22` using `:accordingTo`.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1055,11 +1055,12 @@
       -->
     </pre>
 
-    <p class="note">A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a> is syntactic sugar relating a
-      <a>reifier</a> to a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
-      using the <code>rdf:reifies</code> predicate.
-      Note the difference in syntax between the syntactic sugar of <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-      (i.e., `&lt;&lt; [...] >>`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a> (i.e., `&lt;&lt;( [...] )>>`).</p>
+    <p class="note">A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+      is syntactic sugar that uses the <code>rdf:reifies</code> predicate to relate a <a>reifier</a>
+      to a <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>. Note the difference
+      in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+      (i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
+      (i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
 
     <p>After declaring a prefix so that IRIs can be abbreviated,
       the first triple in this example asserts that `employee38` has a `familyName` of "Smith".

--- a/spec/index.html
+++ b/spec/index.html
@@ -1063,8 +1063,8 @@
         in syntax between the syntactic sugar of a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
         <br>(i.e., `&lt;&lt; [...] &gt;&gt;`) and the regular <a href="#grammar-production-tripleTerm"><code>tripleTerm</code></a>
         <br>(i.e., `&lt;&lt;( [...] )&gt;&gt;`).</p>
-      <p>A <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
-        may be nested inside another, as in
+      <p>Also note that a <a href="#grammar-production-reifiedTriple"><code>reifiedTriple</code></a>
+        can be nested inside another, as in
         <br>`&lt;&lt; :subject1 :predicate1 &lt;&lt; :subject2 :predicate2 :object2 &gt;&gt; ~:IRIREF1 &gt;&gt;`
         or <br>`&lt;&lt; :subject4 :predicate4 &lt;&lt; :subject3 :predicate3 :object3 ~:IRIREF3 &gt;&gt; &gt;&gt;`.</p>
     </div>


### PR DESCRIPTION
Moves the redundant final sentence into the note to improve the flow of the Reifying Triples section.

see https://github.com/w3c/rdf-turtle/issues/155


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/pull/157.html" title="Last updated on Aug 29, 2026, 7:06 AM UTC (e8eb426)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-turtle/157/5043363...e8eb426.html" title="Last updated on Aug 29, 2026, 7:06 AM UTC (e8eb426)">Diff</a>